### PR TITLE
Fix race chart and session toggle

### DIFF
--- a/templates/race.html
+++ b/templates/race.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="container mt-4">
-  <div class="card shadow rounded-4 p-4">
+  <div class="main-card">
     <h2 class="text-center mb-4">{{ track_name }} - Race on {{ race_session.date.strftime('%B %d, %Y at %I:%M %p') }}</h2>
 
     <div class="text-center mb-4">
@@ -24,14 +24,10 @@
     <canvas id="lapChart" height="120"></canvas>
   </div>
 </div>
-
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
+  window.addEventListener("load", () => {
   const lapTimes = {{ laps | tojson }};
   const ctx = document.getElementById('lapChart').getContext('2d');
-
-  const minLap = Math.min(...lapTimes);
-  const maxLap = Math.max(...lapTimes);
 
   new Chart(ctx, {
     type: 'line',
@@ -57,6 +53,14 @@
           callbacks: {
             label: ctx => `${ctx.label}: ${ctx.parsed.y.toFixed(3)}s`
           }
+        },
+        zoom: {
+          pan: { enabled: true, mode: 'x' },
+          zoom: {
+            wheel: { enabled: true },
+            pinch: { enabled: true },
+            mode: 'x'
+          }
         }
       },
       scales: {
@@ -65,24 +69,16 @@
             display: true,
             text: 'Lap Number'
           },
-          ticks: {
-            autoSkip: false
-          }
+          ticks: { autoSkip: false }
         },
         y: {
-          title: {
-            display: true,
-            text: 'Lap Time (s)'
-          },
-          beginAtZero: false,
-          min: minLap - 0.2,
-          max: maxLap + 0.2,
-          ticks: {
-            stepSize: 0.1
-          }
+          title: { display: true, text: 'Lap Time (s)' },
+          reverse: true,
+          ticks: { callback: v => v.toFixed(2) }
         }
       }
     }
+  });
   });
 </script>
 {% endblock %}

--- a/templates/track.html
+++ b/templates/track.html
@@ -56,7 +56,7 @@
             <div id="driftInfo" class="text-muted small"></div>
         </div>
 
-        <!-- Session Table Section (unchanged) -->
+        <!-- Session Table Section -->
         <div class="table-container-ios mt-4">
             <table id="lapsTable" class="table table-striped">
                 <thead>
@@ -89,7 +89,9 @@
                     {% endfor %}
                 </tbody>
             </table>
-            <button id="toggleRows" class="btn btn-outline-secondary btn-sm mt-2">Show All</button>
+        </div>
+        <div class="text-end mb-2">
+            <button id="toggleRows" class="btn btn-outline-secondary btn-sm">Show All</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- ensure race charts initialize after page load and support zooming
- restore track sessions "Show All" button to bottom and keep it visible when scrolling

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865ce8340048326991614b2f955f7e3