### PR TITLE
Fix track table toggle and chart display

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -145,6 +145,14 @@ body {
     margin-bottom: 1rem;
 }
 
+/* Race detail chart */
+#lapChart {
+    display: block;
+    width: 100%;
+    height: 300px !important;
+    margin-bottom: 1rem;
+}
+
 /* Make lap table more usable */
 .table-responsive {
     overflow-x: auto;

--- a/templates/track.html
+++ b/templates/track.html
@@ -58,7 +58,6 @@
 
         <!-- Session Table Section -->
         <div class="table-container-ios mt-4">
-            <button id="toggleRows" class="btn btn-outline-secondary btn-sm mb-2">Show All</button>
             <table id="lapsTable" class="table table-striped">
                 <thead>
                     <tr>
@@ -91,7 +90,7 @@
                 </tbody>
             </table>
 </div>
-<div class="text-end mb-2">
+<div class="text-start mb-2">
   <button id="toggleRows" class="btn btn-outline-secondary btn-sm">Show All</button>
 </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the top "Show All" toggle and keep the bottom one
- position toggle button outside the scrollable table
- add fixed height rules for the race chart so it doesn't stretch

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865e9047948832692273de2cb08bb78