### PR TITLE
Fix race chart scale and table toggle

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -145,6 +145,14 @@ body {
     margin-bottom: 1rem;
 }
 
+/* Race detail chart */
+#lapChart {
+    display: block;
+    width: 100%;
+    height: 300px !important;
+    margin-bottom: 1rem;
+}
+
 /* Make lap table more usable */
 .table-responsive {
     overflow-x: auto;

--- a/templates/race.html
+++ b/templates/race.html
@@ -27,6 +27,8 @@
 <script>
   window.addEventListener("load", () => {
   const lapTimes = {{ laps | tojson }};
+  const baseTime = {{ personal_best | tojson }};
+  const lapDiffs = lapTimes.map(t => t - baseTime);
   const ctx = document.getElementById('lapChart').getContext('2d');
 
   new Chart(ctx, {
@@ -35,7 +37,7 @@
       labels: lapTimes.map((_, i) => `Lap ${i + 1}`),
       datasets: [{
         label: 'Lap Time',
-        data: lapTimes,
+        data: lapDiffs,
         borderColor: '#007bff',
         backgroundColor: 'rgba(0,123,255,0.1)',
         tension: 0.3,
@@ -51,7 +53,7 @@
         legend: { display: false },
         tooltip: {
           callbacks: {
-            label: ctx => `${ctx.label}: ${ctx.parsed.y.toFixed(3)}s`
+            label: ctx => `Lap ${ctx.dataIndex + 1}: ${lapTimes[ctx.dataIndex].toFixed(3)}s`
           }
         },
         zoom: {
@@ -72,8 +74,8 @@
           ticks: { autoSkip: false }
         },
         y: {
-          title: { display: true, text: 'Lap Time (s)' },
-          reverse: true,
+          title: { display: true, text: 'Seconds Over Best' },
+          beginAtZero: true,
           ticks: { callback: v => v.toFixed(2) }
         }
       }

--- a/templates/track.html
+++ b/templates/track.html
@@ -58,7 +58,6 @@
 
         <!-- Session Table Section -->
         <div class="table-container-ios mt-4">
-            <button id="toggleRows" class="btn btn-outline-secondary btn-sm mb-2">Show All</button>
             <table id="lapsTable" class="table table-striped">
                 <thead>
                     <tr>
@@ -91,7 +90,7 @@
                 </tbody>
             </table>
 </div>
-<div class="text-end mb-2">
+<div class="text-start mb-2">
   <button id="toggleRows" class="btn btn-outline-secondary btn-sm">Show All</button>
 </div>
     </div>
@@ -340,7 +339,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });
     document.getElementById('driftToggle').addEventListener('change', updateChart);
 
-    const MAX_ROWS = 20;
+    const MAX_ROWS = 10;
     const table = document.getElementById('lapsTable');
     const btnToggle = document.getElementById('toggleRows');
     const rows = Array.from(table.tBodies[0].rows);


### PR DESCRIPTION
## Summary
- only show 10 sessions by default on the track page
- start race lap chart at the personal best time and show values above it
- keep tooltips showing the original lap times

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865e9047948832692273de2cb08bb78