### PR TITLE
Improve lap charts

### DIFF
--- a/templates/race.html
+++ b/templates/race.html
@@ -28,7 +28,6 @@
   window.addEventListener("load", () => {
   const lapTimes = {{ laps | tojson }};
   const baseTime = {{ personal_best | tojson }};
-  const lapDiffs = lapTimes.map(t => t - baseTime);
   const ctx = document.getElementById('lapChart').getContext('2d');
 
   new Chart(ctx, {
@@ -37,10 +36,10 @@
       labels: lapTimes.map((_, i) => `Lap ${i + 1}`),
       datasets: [{
         label: 'Lap Time',
-        data: lapDiffs,
+        data: lapTimes,
         borderColor: '#007bff',
         backgroundColor: 'rgba(0,123,255,0.1)',
-        tension: 0.3,
+        tension: 0,
         borderWidth: 2,
         pointRadius: 3,
         pointHoverRadius: 6
@@ -49,6 +48,11 @@
     options: {
       responsive: true,
       maintainAspectRatio: false,
+      interaction: {
+        mode: 'nearest',
+        axis: 'x',
+        intersect: false
+      },
       plugins: {
         legend: { display: false },
         tooltip: {
@@ -74,8 +78,8 @@
           ticks: { autoSkip: false }
         },
         y: {
-          title: { display: true, text: 'Seconds Over Best' },
-          beginAtZero: true,
+          title: { display: true, text: 'Lap Time (s)' },
+          min: baseTime,
           ticks: { callback: v => v.toFixed(2) }
         }
       }

--- a/templates/track.html
+++ b/templates/track.html
@@ -184,7 +184,7 @@ document.addEventListener("DOMContentLoaded", function () {
             },
             plugins: {
                 tooltip: { enabled: true },
-                legend: { labels: { color: '#000' } },
+                legend: { display: false },
                 zoom: {
                     pan: { enabled: true, mode: 'x' },
                     zoom: {


### PR DESCRIPTION
## Summary
- show real lap times on race detail chart
- straighten line segments
- match hover interaction to track chart
- hide unhelpful legend button on track charts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865ee25b9b88326ac5473bc70f72ca2