### PR TITLE
Implement advanced drift filtering & race outlier toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -448,7 +448,7 @@ def track_detail(track_name):
     user = User.query.filter_by(email=session['email']).first()
     t    = Track.query.filter_by(raw_name=track_name, user_id=user.id).first()
 
-    sessions, dates, bests = [], [], []
+    sessions, dates, bests, date_times = [], [], [], []
     for s in sorted(t.sessions, key=lambda x: x.date, reverse=True):
         lap_list = eval(s.lap_data or '[]')
         sessions.append({
@@ -461,6 +461,7 @@ def track_detail(track_name):
             'laps': lap_list
         })
         dates.append(s.date.strftime('%Y-%m-%d'))
+        date_times.append(s.date.strftime('%Y-%m-%d %H:%M'))
         bests.append(s.best_lap)
 
     drift_cutoff = 0
@@ -480,7 +481,8 @@ def track_detail(track_name):
         'best_laps': bests,
         'improvement_dates': improvement_dates,
         'improvement_laps': improvement_laps,
-        'drift_cutoff': drift_cutoff
+        'drift_cutoff': drift_cutoff,
+        'date_times': date_times
     }
 
     return render_template('track.html',

--- a/templates/race.html
+++ b/templates/race.html
@@ -21,7 +21,10 @@
       <p>Total Laps: {{ race_session.total_laps }}</p>
     </div>
 
-    <canvas id="lapChart" height="120"></canvas>
+    <div class="chart-container-ios mt-3 mb-2">
+      <canvas id="lapChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+    </div>
+    <button id="toggleOutliers" class="btn btn-outline-secondary btn-sm mb-3">Filter Outliers</button>
   </div>
 </div>
 <script>
@@ -30,7 +33,20 @@
   const baseTime = {{ personal_best | tojson }};
   const ctx = document.getElementById('lapChart').getContext('2d');
 
-  new Chart(ctx, {
+  function calcOutliers(times) {
+    const sorted = [...times].sort((a,b)=>a-b);
+    const q1 = sorted[Math.floor(sorted.length/4)];
+    const q3 = sorted[Math.floor(sorted.length*3/4)];
+    const iqr = q3 - q1;
+    const lower = q1 - 1.5*iqr;
+    const upper = q3 + 1.5*iqr;
+    return times.map(t => t < lower || t > upper);
+  }
+
+  const outlierFlags = calcOutliers(lapTimes);
+  let hideOutliers = false;
+
+  const chart = new Chart(ctx, {
     type: 'line',
     data: {
       labels: lapTimes.map((_, i) => `Lap ${i + 1}`),
@@ -85,6 +101,47 @@
       }
     }
   });
+
+  function updateChart() {
+    const labels = [];
+    const vals = [];
+    for (let i = 0; i < lapTimes.length; i++) {
+      if (!hideOutliers || !outlierFlags[i]) {
+        labels.push(`Lap ${i + 1}`);
+        vals.push(lapTimes[i]);
+      }
+    }
+    chart.data.labels = labels;
+    chart.data.datasets[0].data = vals;
+    chart.update();
+  }
+
+  const btn = document.getElementById('toggleOutliers');
+  btn.addEventListener('click', () => {
+    hideOutliers = !hideOutliers;
+    btn.textContent = hideOutliers ? 'Show Outliers' : 'Filter Outliers';
+    updateChart();
+  });
+
+  updateChart();
   });
 </script>
+<style>
+.chart-container-ios {
+    background-color: #fff;
+    padding: 10px;
+    border-radius: 8px;
+    overflow: hidden;
+    -webkit-overflow-scrolling: touch;
+    width: 100%;
+    touch-action: none;
+}
+
+#lapChart {
+    max-width: 100%;
+    height: auto;
+    max-height: 400px;
+    touch-action: none;
+}
+</style>
 {% endblock %}

--- a/templates/track.html
+++ b/templates/track.html
@@ -54,6 +54,11 @@
             </div>
             <small class="text-muted d-block mt-1"><em>Pinch to zoom may not work on all mobile browsers. Try zooming on desktop for best experience.</em></small>
             <div id="driftInfo" class="text-muted small"></div>
+            <div id="driftAfterDiv" class="small mt-1" style="display:none;">
+                Filter normal races during/after drift nights for
+                <input type="number" id="driftDays" value="1" min="0" class="form-control form-control-sm d-inline w-auto ms-1 me-1">days
+                <button id="applyDriftFilter" class="btn btn-outline-secondary btn-sm">Apply</button>
+            </div>
         </div>
 
         <!-- Session Table Section -->
@@ -144,11 +149,15 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!ctx) return;
 
     const labels = {{ chart_data.dates | tojson }};
+    const times = {{ chart_data.date_times | tojson }};
     const data = {{ chart_data.best_laps | tojson }};
     const driftCutoff = {{ chart_data.drift_cutoff | tojson }};
     const driftFlags = data.map(v => v >= driftCutoff);
     let filteredLabels = labels.slice();
     let filteredData = data.slice();
+    let filteredTimes = times.slice();
+
+    let afterDriftDays = 0;
 
     const improvementLabels = [];
     const improvementData = [];
@@ -239,12 +248,13 @@ document.addEventListener("DOMContentLoaded", function () {
                     if (d >= fromDate && d <= toDate) {
                         acc.labels.push(dateStr);
                         acc.data.push(data[i]);
+                        acc.times.push(times[i]);
                         acc.indices.push(i);
                     }
                     return acc;
-                }, { labels: [], data: [], indices: [] });
+                }, { labels: [], data: [], times: [], indices: [] });
             } else {
-                return { labels: [], data: [], indices: [] };
+                return { labels: [], data: [], times: [], indices: [] };
             }
         }
 
@@ -253,10 +263,11 @@ document.addEventListener("DOMContentLoaded", function () {
             if (!fromDate || d >= fromDate) {
                 acc.labels.push(dateStr);
                 acc.data.push(data[i]);
+                acc.times.push(times[i]);
                 acc.indices.push(i);
             }
             return acc;
-        }, { labels: [], data: [], indices: [] });
+        }, { labels: [], data: [], times: [], indices: [] });
     }
 
     function updateChart() {
@@ -267,30 +278,69 @@ document.addEventListener("DOMContentLoaded", function () {
 
         filteredLabels = result.labels;
         filteredData = result.data;
+        filteredTimes = result.times;
         let indices = result.indices;
+
+        const driftAfterDiv = document.getElementById('driftAfterDiv');
 
         if (document.getElementById('driftToggle').checked) {
             let removed = 0;
             let removedDates = [];
-            let tmpLabels = [], tmpData = [], tmpIndices = [];
+            let driftTimes = [];
+            let tmpLabels = [], tmpData = [], tmpTimes = [], tmpIndices = [];
             for (let i = 0; i < filteredLabels.length; i++) {
                 if (driftFlags[indices[i]]) {
                     removed++;
                     removedDates.push(filteredLabels[i]);
+                    driftTimes.push(new Date(times[indices[i]]));
                 } else {
                     tmpLabels.push(filteredLabels[i]);
                     tmpData.push(filteredData[i]);
+                    tmpTimes.push(filteredTimes[i]);
                     tmpIndices.push(indices[i]);
                 }
             }
             filteredLabels = tmpLabels;
             filteredData = tmpData;
+            filteredTimes = tmpTimes;
             indices = tmpIndices;
             const uniqueDates = [...new Set(removedDates.map(d => d.split(' ')[0]))];
             document.getElementById('driftInfo').textContent =
                 `Filtered ${removed} sessions on ${uniqueDates.length} drift nights. ` + uniqueDates.join(', ');
+            driftAfterDiv.style.display = uniqueDates.length ? 'block' : 'none';
+
+            if (afterDriftDays > 0 && driftTimes.length) {
+                let tmpL = [], tmpD = [], tmpT = [], tmpI = [];
+                let removedAfter = 0;
+                for (let i = 0; i < filteredLabels.length; i++) {
+                    const dt = new Date(filteredTimes[i]);
+                    let exclude = false;
+                    for (const start of driftTimes) {
+                        const start4 = new Date(start);
+                        start4.setHours(16,0,0,0);
+                        const end = new Date(start4);
+                        end.setDate(end.getDate() + afterDriftDays);
+                        if (dt >= start4 && dt <= end) { exclude = true; break; }
+                    }
+                    if (exclude) {
+                        removedAfter++;
+                    } else {
+                        tmpL.push(filteredLabels[i]);
+                        tmpD.push(filteredData[i]);
+                        tmpT.push(filteredTimes[i]);
+                        tmpI.push(indices[i]);
+                    }
+                }
+                filteredLabels = tmpL;
+                filteredData = tmpD;
+                filteredTimes = tmpT;
+                indices = tmpI;
+                if (removedAfter)
+                    document.getElementById('driftInfo').textContent += ` Filtered ${removedAfter} more sessions after drift nights.`;
+            }
         } else {
             document.getElementById('driftInfo').textContent = '';
+            driftAfterDiv.style.display = 'none';
         }
 
         if (viewMode === 'improvement') {
@@ -338,6 +388,13 @@ document.addEventListener("DOMContentLoaded", function () {
         chart.resetZoom();
     });
     document.getElementById('driftToggle').addEventListener('change', updateChart);
+    const applyBtn = document.getElementById('applyDriftFilter');
+    if (applyBtn) {
+        applyBtn.addEventListener('click', () => {
+            afterDriftDays = parseInt(document.getElementById('driftDays').value) || 0;
+            updateChart();
+        });
+    }
 
     const MAX_ROWS = 10;
     const table = document.getElementById('lapsTable');


### PR DESCRIPTION
## Summary
- keep full session timestamps for filtering
- add drift-night follow-up filter and toggle on track page
- apply iOS chart container styling to race view
- add outlier filtering button on race charts

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6865f0af1bfc8326aa923f6f2a3fd9e7