### PR TITLE
Improve lap display and drift filtering

### DIFF
--- a/templates/race.html
+++ b/templates/race.html
@@ -24,7 +24,8 @@
     <div class="chart-container-ios mt-3 mb-2">
       <canvas id="lapChart" style="touch-action:none; width:100%; height:400px;"></canvas>
     </div>
-    <button id="toggleOutliers" class="btn btn-outline-secondary btn-sm mb-3">Filter Outliers</button>
+    <button id="toggleOutliers" class="btn btn-warning btn-sm mb-1">Filter Outliers</button>
+    <div id="outlierInfo" class="text-muted small mb-3"></div>
   </div>
 </div>
 <script>
@@ -96,7 +97,7 @@
         y: {
           title: { display: true, text: 'Lap Time (s)' },
           min: baseTime,
-          ticks: { callback: v => v.toFixed(2) }
+          ticks: { callback: v => v.toFixed(3) }
         }
       }
     }
@@ -105,15 +106,24 @@
   function updateChart() {
     const labels = [];
     const vals = [];
+    const removed = [];
     for (let i = 0; i < lapTimes.length; i++) {
       if (!hideOutliers || !outlierFlags[i]) {
         labels.push(`Lap ${i + 1}`);
         vals.push(lapTimes[i]);
+      } else {
+        removed.push(`Lap ${i + 1}: ${lapTimes[i].toFixed(3)}s`);
       }
     }
     chart.data.labels = labels;
     chart.data.datasets[0].data = vals;
     chart.update();
+    const info = document.getElementById('outlierInfo');
+    if (hideOutliers && removed.length) {
+      info.textContent = 'Filtered ' + removed.join(', ');
+    } else {
+      info.textContent = '';
+    }
   }
 
   const btn = document.getElementById('toggleOutliers');

--- a/templates/track.html
+++ b/templates/track.html
@@ -85,7 +85,7 @@
                         <td>{{ "%.3f"|format(s.avg_lap|float) }}</td>
                         <td>{{ s.fastest_lap_num }}</td>
                         {% for lap in s.laps %}
-                        <td>{{ lap }}</td>
+                        <td>{{ "%.3f"|format(lap|float) }}</td>
                         {% endfor %}
                         {% for i in range(16 - s.laps|length) %}
                         <td></td>
@@ -309,7 +309,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 `Filtered ${removed} sessions on ${uniqueDates.length} drift nights. ` + uniqueDates.join(', ');
             driftAfterDiv.style.display = uniqueDates.length ? 'block' : 'none';
 
-            if (afterDriftDays > 0 && driftTimes.length) {
+            if (afterDriftDays >= 0 && driftTimes.length) {
                 let tmpL = [], tmpD = [], tmpT = [], tmpI = [];
                 let removedAfter = 0;
                 for (let i = 0; i < filteredLabels.length; i++) {
@@ -320,6 +320,7 @@ document.addEventListener("DOMContentLoaded", function () {
                         start4.setHours(16,0,0,0);
                         const end = new Date(start4);
                         end.setDate(end.getDate() + afterDriftDays);
+                        end.setHours(23,59,59,999);
                         if (dt >= start4 && dt <= end) { exclude = true; break; }
                     }
                     if (exclude) {


### PR DESCRIPTION
## Summary
- show outlier filtering status on race charts
- keep lap table data to three decimals
- show y‑axis tick labels with three decimal precision
- clarify drift-day filtering logic

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6865f45a7fc08326a41870af23e6e4ca