### PR TITLE
Update track ordering and filtering logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -449,7 +449,7 @@ def track_detail(track_name):
     t    = Track.query.filter_by(raw_name=track_name, user_id=user.id).first()
 
     sessions, dates, bests, date_times = [], [], [], []
-    for s in sorted(t.sessions, key=lambda x: x.date, reverse=True):
+    for s in sorted(t.sessions, key=lambda x: x.date):
         lap_list = eval(s.lap_data or '[]')
         sessions.append({
             'id': s.id,

--- a/templates/race.html
+++ b/templates/race.html
@@ -8,7 +8,7 @@
     <div class="text-center mb-4">
       {% if race_session.best_lap == personal_best %}
         <h5>Fastest Lap: <strong>{{ '%.3f' % race_session.best_lap }}s</strong>
-          <span class="badge bg-success ms-2">🎉 New Personal Record!</span>
+          <span class="badge bg-success ms-2">Personal Track Best</span>
         </h5>
       {% else %}
         <h5>Fastest Lap: <strong>{{ '%.3f' % race_session.best_lap }}s</strong>

--- a/templates/track.html
+++ b/templates/track.html
@@ -309,7 +309,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 `Filtered ${removed} sessions on ${uniqueDates.length} drift nights. ` + uniqueDates.join(', ');
             driftAfterDiv.style.display = uniqueDates.length ? 'block' : 'none';
 
-            if (afterDriftDays >= 0 && driftTimes.length) {
+            if (afterDriftDays > 0 && driftTimes.length) {
                 let tmpL = [], tmpD = [], tmpT = [], tmpI = [];
                 let removedAfter = 0;
                 for (let i = 0; i < filteredLabels.length; i++) {
@@ -319,7 +319,7 @@ document.addEventListener("DOMContentLoaded", function () {
                         const start4 = new Date(start);
                         start4.setHours(16,0,0,0);
                         const end = new Date(start4);
-                        end.setDate(end.getDate() + afterDriftDays);
+                        end.setDate(end.getDate() + afterDriftDays - 1);
                         end.setHours(23,59,59,999);
                         if (dt >= start4 && dt <= end) { exclude = true; break; }
                     }
@@ -438,7 +438,14 @@ document.addEventListener("DOMContentLoaded", function () {
             if (!isNaN(nA) && !isNaN(nB)) return (nA - nB) * dir;
             return A.localeCompare(B) * dir;
         });
+
         rows.forEach(r => tbody.appendChild(r));
+
+        const expanded = btnToggle.textContent === 'Show Less';
+        rows.forEach((r, i) => {
+            if (!expanded && i >= MAX_ROWS) r.classList.add('d-none');
+            else r.classList.remove('d-none');
+        });
     };
 });
 </script>


### PR DESCRIPTION
## Summary
- sort track tables chronologically (oldest first)
- tune drift-night filter options
- show `Personal Track Best` text without emoji
- reapply hidden rows when sorting session table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f94e30008326866503ce8af411d3