### PR TITLE
Update chart controls and table UI

### DIFF
--- a/templates/track.html
+++ b/templates/track.html
@@ -39,7 +39,6 @@
                     <label for="toDate" class="form-label me-1">To:</label>
                     <input type="date" id="toDate" class="form-control form-control-sm d-inline w-auto" placeholder="mm/dd/yyyy">
                 </div>
-                <button id="resetZoom" class="btn btn-outline-secondary btn-sm">Reset Zoom</button>
                 <div class="form-check ms-2">
                     <input class="form-check-input" type="checkbox" id="driftToggle">
                     <label class="form-check-label" for="driftToggle">Hide Likely Drift Nights</label>
@@ -52,7 +51,10 @@
                     <canvas id="progressChart" style="touch-action: none; width: 100%; height: 400px;"></canvas>
                 </div>
             </div>
-            <small class="text-muted d-block mt-1"><em>Pinch to zoom may not work on all mobile browsers. Try zooming on desktop for best experience.</em></small>
+            <div class="d-flex justify-content-between align-items-center mt-1">
+                <small class="text-muted"><em>Zoom may not work on all mobile browsers. Try desktop.</em></small>
+                <button id="resetZoom" class="btn btn-outline-secondary btn-sm ms-2">Reset Zoom</button>
+            </div>
             <div id="driftInfo" class="text-muted small"></div>
             <div id="driftAfterDiv" class="small mt-1" style="display:none;">
                 Filter normal races during/after drift nights for
@@ -63,17 +65,17 @@
 
         <!-- Session Table Section -->
         <div class="table-container-ios mt-4">
-            <div class="small text-muted mb-1">Click any column header to sort the table.</div>
+            <div class="small text-muted mb-1">Click any column header to sort the table. Click any session date to view session details.</div>
             <table id="lapsTable" class="table table-striped">
                 <thead>
                     <tr>
-                        <th class="sortable-header" onclick="sortTable(0)"><u>Date</u> <span class="sort-icons">⇅</span></th>
-                        <th class="sortable-header" onclick="sortTable(1)"><u>Total Laps</u> <span class="sort-icons">⇅</span></th>
-                        <th class="sortable-header" onclick="sortTable(2)"><u>Best Lap</u> <span class="sort-icons">⇅</span></th>
-                        <th class="sortable-header" onclick="sortTable(3)"><u>Avg Lap</u> <span class="sort-icons">⇅</span></th>
-                        <th class="sortable-header" onclick="sortTable(4)"><u>Fastest Lap #</u> <span class="sort-icons">⇅</span></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(0)">Date <span class="sort-icons">⇅</span></button></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(1)">Total Laps <span class="sort-icons">⇅</span></button></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(2)">Best Lap <span class="sort-icons">⇅</span></button></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(3)">Avg Lap <span class="sort-icons">⇅</span></button></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(4)">Fastest Lap # <span class="sort-icons">⇅</span></button></th>
                         {% for i in range(1, 17) %}
-                        <th class="sortable-header" onclick="sortTable({{ i + 4 }})"><u>Lap {{ i }}</u> <span class="sort-icons">⇅</span></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable({{ i + 4 }})">Lap {{ i }} <span class="sort-icons">⇅</span></button></th>
                         {% endfor %}
                     </tr>
                 </thead>
@@ -146,13 +148,15 @@
 /* Style for sortable table headers */
 #lapsTable th.sortable-header {
     background-color: #f8f9fa;
-    color: #0d6efd;
-    cursor: pointer;
     user-select: none;
 }
 
 #lapsTable th.sortable-header:hover {
     background-color: #e2e6ea;
+}
+
+.sort-button {
+    width: 100%;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- move reset zoom button under chart
- tweak mobile zoom disclaimer
- clarify sorting help text
- convert sortable table headers to button UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865fff8fccc8326bf832136b3b766b9