### PR TITLE
Enhance chart buttons and track cards

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -86,6 +86,7 @@ body {
 }
 
 .track-card {
+    position: relative;
     background: rgba(255,255,255,0.9);
     border-radius: 8px;
     padding: 1.5rem;
@@ -96,6 +97,16 @@ body {
 .track-card:hover {
     transform: translateY(-3px);
     text-decoration: none;
+}
+
+.track-card-img {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 60px;
+    height: 60px;
+    object-fit: cover;
+    border-radius: 4px;
 }
 
 /* Charts */

--- a/templates/results.html
+++ b/templates/results.html
@@ -26,7 +26,8 @@
   <div class="row">
     {% for track_name, data in tracks.items() %}
     <div class="col-md-6 mb-4">
-      <div class="card h-100">
+      <div class="card h-100 track-card position-relative">
+        <img src="{{ url_for('static', filename='img/tracks/' + data.raw_name + '.jpeg') }}" class="track-card-img" alt="{{ track_name }}">
         <div class="card-body d-flex flex-column">
           <h5 class="card-title">{{ track_name }}</h5>
           <p class="card-text mb-1">Sessions: {{ data.sessions }}</p>

--- a/templates/track.html
+++ b/templates/track.html
@@ -53,13 +53,13 @@
             </div>
             <div class="d-flex justify-content-between align-items-center mt-1">
                 <small class="text-muted"><em>Zoom may not work on all mobile browsers. Try desktop.</em></small>
-                <button id="resetZoom" class="btn btn-outline-secondary btn-sm ms-2">Reset Zoom</button>
+                <button id="resetZoom" class="btn btn-outline-secondary btn-sm ms-2 chart-btn">Reset Zoom</button>
             </div>
             <div id="driftInfo" class="text-muted small"></div>
             <div id="driftAfterDiv" class="small mt-1" style="display:none;">
                 Filter normal races during/after drift nights for
                 <input type="number" id="driftDays" value="1" min="0" class="form-control form-control-sm d-inline w-auto ms-1 me-1">days
-                <button id="applyDriftFilter" class="btn btn-outline-secondary btn-sm">Apply</button>
+                <button id="applyDriftFilter" class="btn btn-outline-secondary btn-sm chart-btn">Apply</button>
             </div>
         </div>
 
@@ -99,7 +99,7 @@
             </table>
 </div>
 <div class="text-start mb-2">
-  <button id="toggleRows" class="btn btn-outline-secondary btn-sm">Show All</button>
+  <button id="toggleRows" class="btn btn-outline-secondary btn-sm chart-btn">Show All</button>
 </div>
     </div>
 </div>
@@ -157,6 +157,18 @@
 
 .sort-button {
     width: 100%;
+}
+
+.chart-btn,
+.sort-button {
+    background-color: #e74c3c;
+    border: 1px solid #000;
+    color: #fff;
+}
+
+.chart-btn:hover,
+.sort-button:hover {
+    background-color: #c0392b;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- color chart page buttons red with a black outline
- display track images on results cards

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686606ad4998832686b7d111619f785c