### PR TITLE
Fix track image filenames

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,6 +116,12 @@ def filter_laps_by_cutoff(display_location, laps):
     return [lap for lap in laps if lap >= cutoff]
 
 
+def track_image_filename(raw_name):
+    """Return the standardized track image filename."""
+    name = raw_name.strip().lower().replace(' ', '_')
+    return f"{name}.jpeg"
+
+
 def parse_email(msg, k1_name):
     """Parse a K1 speed results email into structured data."""
     body = extract_email_body(msg)
@@ -428,11 +434,12 @@ def results():
         best    = min(t.sessions, key=lambda s: s.best_lap)
         first   = min(t.sessions, key=lambda s: s.date)
         tracks_data[t.display_name] = {
-            'raw_name'  : t.raw_name,
-            'sessions'  : len(t.sessions),
-            'first_date': first.date.strftime('%Y-%m-%d'),
-            'best_lap'  : f"{best.best_lap:.3f}",
-            'best_date' : best.date.strftime('%Y-%m-%d')
+            'raw_name'   : t.raw_name,
+            'image_file' : track_image_filename(t.raw_name),
+            'sessions'   : len(t.sessions),
+            'first_date' : first.date.strftime('%Y-%m-%d'),
+            'best_lap'   : f"{best.best_lap:.3f}",
+            'best_date'  : best.date.strftime('%Y-%m-%d')
         }
 
     return render_template('results.html',

--- a/templates/results.html
+++ b/templates/results.html
@@ -27,7 +27,7 @@
     {% for track_name, data in tracks.items() %}
     <div class="col-md-6 mb-4">
       <div class="card h-100 track-card position-relative">
-        <img src="{{ url_for('static', filename='img/tracks/' + data.raw_name + '.jpeg') }}" class="track-card-img" alt="{{ track_name }}">
+        <img src="{{ url_for('static', filename='img/tracks/' ~ data.image_file) }}" class="track-card-img" alt="{{ track_name }}">
         <div class="card-body d-flex flex-column">
           <h5 class="card-title">{{ track_name }}</h5>
           <p class="card-text mb-1">Sessions: {{ data.sessions }}</p>


### PR DESCRIPTION
## Summary
- create `track_image_filename` helper to normalize track image filenames
- include `image_file` in results data
- use normalized filenames in results template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686609931cf883268a44f18d277c9bb4