### PR TITLE
UI tweaks and table column reorder

### DIFF
--- a/app.py
+++ b/app.py
@@ -442,9 +442,20 @@ def results():
             'best_date'  : best.date.strftime('%Y-%m-%d')
         }
 
-    return render_template('results.html',
-                           username=user.username,
-                           tracks=tracks_data)
+    sorted_tracks = sorted(
+        tracks_data.items(),
+        key=lambda x: x[1]['sessions'],
+        reverse=True
+    )
+
+    total_races = sum(len(t.sessions) for t in user.tracks)
+
+    return render_template(
+        'results.html',
+        username=user.username,
+        tracks=sorted_tracks,
+        total_races=total_races
+    )
 
 
 @app.route('/track/<track_name>')

--- a/static/styles.css
+++ b/static/styles.css
@@ -89,8 +89,9 @@ body {
     position: relative;
     background: rgba(255,255,255,0.9);
     border-radius: 8px;
-    padding: 1.5rem;
-    text-align: center;
+    overflow: hidden;
+    padding: 0;
+    text-align: left;
     transition: transform 0.2s;
 }
 
@@ -100,13 +101,10 @@ body {
 }
 
 .track-card-img {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    width: 60px;
-    height: 60px;
+    width: 100%;
+    height: 180px;
     object-fit: cover;
-    border-radius: 4px;
+    border-radius: 8px 8px 0 0;
 }
 
 /* Charts */

--- a/templates/results.html
+++ b/templates/results.html
@@ -7,8 +7,8 @@
   <div class="main-card mb-4 p-4">
     <div>
       <h3 class="mb-1">{{ username }}</h3>
-      <p class="mb-1"><strong>Total Races:</strong>
-        {{ tracks.values()|sum(attribute='sessions') }}</p>
+  <p class="mb-1"><strong>Total Races:</strong>
+        {{ total_races }}</p>
       <div class="mt-2">
         <a href="{{ url_for('profile_setup') }}"
            class="btn btn-sm btn-outline-secondary me-2">
@@ -23,12 +23,12 @@
   </div>
 
   <!-- Grid of track summary cards -->
-  <div class="row">
-    {% for track_name, data in tracks.items() %}
-    <div class="col-md-6 mb-4">
-      <div class="card h-100 track-card position-relative">
-        <img src="{{ url_for('static', filename='img/tracks/' ~ data.image_file) }}" class="track-card-img" alt="{{ track_name }}">
-        <div class="card-body d-flex flex-column">
+    <div class="row">
+      {% for track_name, data in tracks %}
+      <div class="col-md-6 mb-4">
+        <div class="card h-100 track-card">
+          <img src="{{ url_for('static', filename='img/tracks/' ~ data.image_file) }}" class="track-card-img card-img-top" alt="{{ track_name }}">
+          <div class="card-body d-flex flex-column">
           <h5 class="card-title">{{ track_name }}</h5>
           <p class="card-text mb-1">Sessions: {{ data.sessions }}</p>
           <p class="card-text mb-1">First Race: {{ data.first_date }}</p>

--- a/templates/track.html
+++ b/templates/track.html
@@ -70,9 +70,9 @@
                 <thead>
                     <tr>
                         <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(0)">Date <span class="sort-icons">⇅</span></button></th>
-                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(1)">Total Laps <span class="sort-icons">⇅</span></button></th>
-                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(2)">Best Lap <span class="sort-icons">⇅</span></button></th>
-                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(3)">Avg Lap <span class="sort-icons">⇅</span></button></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(1)">Best Lap <span class="sort-icons">⇅</span></button></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(2)">Avg Lap <span class="sort-icons">⇅</span></button></th>
+                        <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(3)">Total Laps <span class="sort-icons">⇅</span></button></th>
                         <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(4)">Fastest Lap # <span class="sort-icons">⇅</span></button></th>
                         {% for i in range(1, 17) %}
                         <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable({{ i + 4 }})">Lap {{ i }} <span class="sort-icons">⇅</span></button></th>
@@ -83,9 +83,9 @@
                     {% for s in sessions %}
                     <tr>
                         <td data-sort="{{ s.date }}"><a href="{{ url_for('race_detail', session_id=s.id) }}">{{ s.date }}</a></td>
-                        <td>{{ s.total_laps }}</td>
                         <td>{{ "%.3f"|format(s.best_lap|float) }}</td>
                         <td>{{ "%.3f"|format(s.avg_lap|float) }}</td>
+                        <td>{{ s.total_laps }}</td>
                         <td>{{ s.fastest_lap_num }}</td>
                         {% for lap in s.laps %}
                         <td>{{ "%.3f"|format(lap|float) }}</td>


### PR DESCRIPTION
## Summary
- enlarge track card images and left align text
- sort results cards by number of races
- move total laps column in track table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68660db676e083268df6e1977bccfc1f