### PR TITLE
Fix track card images

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -102,8 +102,8 @@ body {
 
 .track-card-img {
     width: 100%;
-    height: 180px;
-    object-fit: cover;
+    max-height: 180px;
+    object-fit: contain;
     border-radius: 8px 8px 0 0;
 }
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -30,10 +30,13 @@
           <img src="{{ url_for('static', filename='img/tracks/' ~ data.image_file) }}" class="track-card-img card-img-top" alt="{{ track_name }}">
           <div class="card-body d-flex flex-column">
           <h5 class="card-title">{{ track_name }}</h5>
-          <p class="card-text mb-1">Sessions: {{ data.sessions }}</p>
-          <p class="card-text mb-1">First Race: {{ data.first_date }}</p>
-          <p class="card-text mb-3">
-            Fastest Lap: {{ data.best_lap }}s ({{ data.best_date }})
+          <p class="card-text mb-1 d-flex justify-content-between">
+            <span>Sessions: {{ data.sessions }}</span>
+            <span>First: {{ data.first_date }}</span>
+          </p>
+          <p class="card-text mb-3 d-flex justify-content-between">
+            <span>Fastest: {{ data.best_lap }}s</span>
+            <span>{{ data.best_date }}</span>
           </p>
           <a href="{{ url_for('track_detail', track_name=data.raw_name) }}"
              class="mt-auto btn btn-primary">


### PR DESCRIPTION
## Summary
- ensure track card images show completely by using `object-fit: contain`
- condense track card text to two lines so images get more space

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68660ff31a588326879a8c923b6646d7