### PR TITLE
Fix scatter chart to use unified date axis

### DIFF
--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -100,22 +100,56 @@ document.addEventListener("DOMContentLoaded", function () {
 
     function buildDatasets(sortBy, range) {
         const { fromDate, toDate } = getRange(range);
-        let maxCount = 0;
-        const datasets = trackNames.map((name, idx) => {
-            const data = [];
+        let earliest = null;
+        let latest = null;
+        const countsPerTrack = {};
+
+        trackNames.forEach(name => {
             const counts = {};
-            const dates = trackData[name].slice().sort();
+            const dates = trackData[name];
             for (const d of dates) {
                 const dt = new Date(d);
                 if (fromDate && dt < fromDate) continue;
                 if (toDate && dt > toDate) continue;
+                if (!earliest || dt < earliest) earliest = new Date(dt);
+                if (!latest || dt > latest) latest = new Date(dt);
                 let key = d;
                 if (sortBy === 'month') key = d.slice(0, 7);
                 else if (sortBy === 'year') key = d.slice(0, 4);
                 counts[key] = (counts[key] || 0) + 1;
-                data.push({ x: key, y: counts[key] });
-                if (counts[key] > maxCount) maxCount = counts[key];
             }
+            countsPerTrack[name] = counts;
+        });
+
+        if (!earliest || !latest) {
+            return { labels: [], datasets: [], maxCount: 0 };
+        }
+
+        const start = fromDate ? new Date(fromDate) : earliest;
+        const end = toDate ? new Date(toDate) : latest;
+        const labels = [];
+        const current = new Date(start);
+        while (current <= end) {
+            if (sortBy === 'month') {
+                labels.push(current.toISOString().slice(0, 7));
+                current.setMonth(current.getMonth() + 1);
+            } else if (sortBy === 'year') {
+                labels.push(String(current.getFullYear()));
+                current.setFullYear(current.getFullYear() + 1);
+            } else {
+                labels.push(current.toISOString().slice(0, 10));
+                current.setDate(current.getDate() + 1);
+            }
+        }
+
+        let maxCount = 0;
+        const datasets = trackNames.map((name, idx) => {
+            const counts = countsPerTrack[name] || {};
+            const data = labels.map(l => {
+                const val = counts[l] || 0;
+                if (val > maxCount) maxCount = val;
+                return { x: l, y: val };
+            });
             return {
                 label: name,
                 data: data,
@@ -125,13 +159,15 @@ document.addEventListener("DOMContentLoaded", function () {
                 showLine: false
             };
         });
-        return { datasets, maxCount };
+
+        return { labels, datasets, maxCount };
     }
 
     function updateChart() {
         const range = document.getElementById('rangeFilter').value;
         const sortBy = document.getElementById('sortBy').value;
         const result = buildDatasets(sortBy, range);
+        chart.data.labels = result.labels;
         chart.data.datasets = result.datasets;
         chart.options.scales.y.max = result.maxCount + 1;
         chart.update();


### PR DESCRIPTION
## Summary
- adjust dataset builder so all tracks share the same chronological labels
- fill in zero-count dates for missing data and use these labels on the axis

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686615ab07848326b0a6a9773169e4e1