### PR TITLE
Add WIP note and disable hover on visit data chart

### DIFF
--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -8,6 +8,7 @@
       <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">Back to Results</a>
     </div>
     <p><strong>Favourite Track:</strong> {{ favourite_track }}</p>
+    <p class="text-warning mb-2"><em>This page is a work in progress.</em></p>
 
     <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
       <label for="rangeFilter" class="form-label me-2">Time Range:</label>
@@ -63,7 +64,12 @@ document.addEventListener("DOMContentLoaded", function () {
         data: { datasets: [] },
         options: {
             responsive: true,
-            plugins: { legend: { display: true } },
+            plugins: {
+                legend: { display: true },
+                tooltip: { enabled: false }
+            },
+            hover: { mode: null },
+            interaction: { mode: null },
             scales: {
                 x: { type: 'category', title: { display: true, text: 'Date' } },
                 y: {


### PR DESCRIPTION
## Summary
- show a "work in progress" note on the Visit Data page
- disable hover interactions on the Visit Data scatter chart

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866237c63c08326943c28266575ff93