### PR TITLE
Add coming soon placeholder and login note

### DIFF
--- a/app.py
+++ b/app.py
@@ -433,9 +433,12 @@ def results():
             continue
         best    = min(t.sessions, key=lambda s: s.best_lap)
         first   = min(t.sessions, key=lambda s: s.date)
+        image_file = track_image_filename(t.raw_name)
+        image_path = os.path.join(app.root_path, 'static', 'img', 'tracks', image_file)
         tracks_data[t.display_name] = {
             'raw_name'   : t.raw_name,
-            'image_file' : track_image_filename(t.raw_name),
+            'image_file' : image_file,
+            'has_image'  : os.path.exists(image_path),
             'sessions'   : len(t.sessions),
             'first_date' : first.date.strftime('%Y-%m-%d'),
             'best_lap'   : f"{best.best_lap:.3f}",

--- a/static/styles.css
+++ b/static/styles.css
@@ -108,6 +108,21 @@ body {
     margin-top: 20px; /* provide visual spacing so image is centered */
 }
 
+.track-card-placeholder {
+    width: 100%;
+    max-height: 180px;
+    height: 180px;
+    border-radius: 8px 8px 0 0;
+    margin-top: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0,0,0,0.05);
+    color: #555;
+    font-size: 1rem;
+    font-weight: bold;
+}
+
 /* Charts */
 .chart-container {
     padding: 1.5rem;

--- a/templates/imap_login.html
+++ b/templates/imap_login.html
@@ -28,10 +28,10 @@
                 <label class="form-label">App-Specific Password</label>
                 <input type="password" name="password" class="form-control" required>
                 <small class="text-muted d-block mt-1">
-                    <strong>Important:</strong> For security, use an app-specific password:
+                    <strong>Important:</strong> For security, use an app-specific password. For added security you can delete the password each time you're done using the app:
                 </small>
                 <ul class="small text-muted ps-3 mt-1">
-                    <li><a href="https://support.google.com/accounts/answer/185833" target="_blank">Gmail Instructions</a></li>
+                    <li><a href="https://myaccount.google.com/apppasswords" target="_blank">Gmail Instructions</a></li>
                     <li><a href="https://help.apple.com/icloud/#/dev3a99c663e" target="_blank">iCloud Instructions</a></li>
                     <li><a href="https://support.microsoft.com/en-us/account-billing/create-an-app-password-for-office-365-3e7c8607-db73-4003-90cb-90f9e8d3b6b4" target="_blank">Outlook Instructions</a></li>
                     <li><a href="https://help.yahoo.com/kb/generate-manage-third-party-passwords-sln15241.html" target="_blank">Yahoo Instructions</a></li>

--- a/templates/results.html
+++ b/templates/results.html
@@ -31,7 +31,13 @@
       {% for track_name, data in tracks %}
       <div class="col-md-6 mb-4">
         <div class="card h-100 track-card">
+          {% if data.has_image %}
           <img src="{{ url_for('static', filename='img/tracks/' ~ data.image_file) }}" class="track-card-img card-img-top" alt="{{ track_name }}">
+          {% else %}
+          <div class="track-card-placeholder card-img-top">
+            🚧 Coming Soon 🚧
+          </div>
+          {% endif %}
           <div class="card-body d-flex flex-column">
           <h5 class="card-title">{{ track_name }}</h5>
           <p class="card-text mb-1 d-flex justify-content-between">


### PR DESCRIPTION
## Summary
- show "Coming Soon" placeholder on results cards when track images are missing
- add CSS for placeholder style
- update login instructions and Gmail link
- detect missing track images in `results` route

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682344dc58832696c5d9e77f5ecead