### PR TITLE
Add disclaimers and dashboard features

### DIFF
--- a/templates/profile_found.html
+++ b/templates/profile_found.html
@@ -23,6 +23,7 @@
                     <i class="bi bi-cloud-arrow-down"></i> Import New Races
                 </button>
             </form>
+            <p class="small text-muted">K1 Circuit and international results might not be handled correctly.</p>
             
             <div class="d-grid gap-2">
                 <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">

--- a/templates/race.html
+++ b/templates/race.html
@@ -25,6 +25,10 @@
       <canvas id="lapChart" style="touch-action:none; width:100%; height:400px;"></canvas>
     </div>
     <button id="toggleOutliers" class="btn btn-warning btn-sm mb-1">Filter Outliers</button>
+    <div class="input-group input-group-sm mb-1 mt-1" style="max-width: 200px;">
+      <input type="number" step="0.001" id="manualMax" class="form-control" placeholder="Max lap (s)">
+      <button id="applyManualMax" class="btn btn-outline-secondary">Apply</button>
+    </div>
     <div id="outlierInfo" class="text-muted small mb-3"></div>
   </div>
 </div>
@@ -46,6 +50,7 @@
 
   const outlierFlags = calcOutliers(lapTimes);
   let hideOutliers = false;
+  let manualMax = null;
 
   const chart = new Chart(ctx, {
     type: 'line',
@@ -108,10 +113,12 @@
     const vals = [];
     const removed = [];
     for (let i = 0; i < lapTimes.length; i++) {
-      if (!hideOutliers || !outlierFlags[i]) {
+      const isOutlier = outlierFlags[i];
+      const withinMax = manualMax === null || lapTimes[i] <= manualMax;
+      if ((!hideOutliers || !isOutlier) && withinMax) {
         labels.push(`Lap ${i + 1}`);
         vals.push(lapTimes[i]);
-      } else {
+      } else if (hideOutliers && isOutlier) {
         removed.push(`Lap ${i + 1}: ${lapTimes[i].toFixed(3)}s`);
       }
     }
@@ -132,6 +139,15 @@
     btn.textContent = hideOutliers ? 'Show Outliers' : 'Filter Outliers';
     updateChart();
   });
+
+  const applyBtn = document.getElementById('applyManualMax');
+  if (applyBtn) {
+    applyBtn.addEventListener('click', () => {
+      const val = parseFloat(document.getElementById('manualMax').value);
+      if (!isNaN(val)) manualMax = val; else manualMax = null;
+      updateChart();
+    });
+  }
 
   updateChart();
   });

--- a/templates/results.html
+++ b/templates/results.html
@@ -22,6 +22,7 @@
            class="btn btn-sm btn-primary">
           Import New Races
         </a>
+        <p class="small text-muted mt-1">K1 Circuit and international results may not be detected correctly.</p>
       </div>
     </div>
   </div>

--- a/templates/track.html
+++ b/templates/track.html
@@ -10,8 +10,10 @@
             </a>
         </div>
 
-        <!-- Chart Section -->
-        <div class="mt-3">
+        <!-- Chart & Table Row -->
+        <div class="row mt-3 g-3">
+          <div class="col-lg-6">
+            <!-- Chart Section -->
             <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
                 <div>
                     <label for="timeFilter" class="form-label me-2">Lap View:</label>
@@ -61,12 +63,13 @@
                 <input type="number" id="driftDays" value="1" min="0" class="form-control form-control-sm d-inline w-auto ms-1 me-1">days
                 <button id="applyDriftFilter" class="btn btn-outline-secondary btn-sm chart-btn">Apply</button>
             </div>
-        </div>
+          </div>
 
-        <!-- Session Table Section -->
-        <div class="table-container-ios mt-4">
-            <div class="small text-muted mb-1">Click any column header to sort the table. Click any session date to view session details.</div>
-            <table id="lapsTable" class="table table-striped">
+          <!-- Session Table Section -->
+          <div class="col-lg-6">
+            <div class="table-container-ios mt-4 mt-lg-0">
+                <div class="small text-muted mb-1">Click any column header to sort the table. Click any session date to view session details.</div>
+                <table id="lapsTable" class="table table-striped">
                 <thead>
                     <tr>
                         <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(0)">Date <span class="sort-icons">⇅</span></button></th>
@@ -97,10 +100,12 @@
                     {% endfor %}
                 </tbody>
             </table>
-</div>
-<div class="text-start mb-2">
-  <button id="toggleRows" class="btn btn-outline-secondary btn-sm chart-btn">Show All</button>
-</div>
+            </div>
+            <div class="text-start mb-2">
+              <button id="toggleRows" class="btn btn-outline-secondary btn-sm chart-btn">Show All</button>
+            </div>
+          </div>
+        </div>
     </div>
 </div>
 

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -2,18 +2,19 @@
 
 {% block content %}
 <div class="container mt-4">
-  <div class="main-card">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h2>Visit Data</h2>
-      <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">Back to Results</a>
-    </div>
-    <p><strong>Favourite Track:</strong> {{ favourite_track }}</p>
-    <p class="text-dark mb-2"><em>⚠️ This page is a work in progress ⚠️</em></p>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Visit Data</h2>
+    <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">Back to Results</a>
+  </div>
+  <p><strong>Favourite Track:</strong> {{ favourite_track }}</p>
 
-    <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-      <label for="rangeFilter" class="form-label me-2">Time Range:</label>
-      <select id="rangeFilter" class="form-select form-select-sm d-inline w-auto">
-        <option value="all" selected>All Time</option>
+  <div class="row g-3">
+    <div class="col-12">
+      <div class="main-card">
+        <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+          <label for="rangeFilter" class="form-label me-2">Time Range:</label>
+          <select id="rangeFilter" class="form-select form-select-sm d-inline w-auto">
+            <option value="all" selected>All Time</option>
         <option value="this_week">This Week</option>
         <option value="this_month">This Month</option>
         <option value="this_year">This Year</option>
@@ -32,10 +33,29 @@
         <label for="toDate" class="form-label me-1">To:</label>
         <input type="date" id="toDate" class="form-control form-control-sm d-inline w-auto">
       </div>
+        </div>
+      </div>
     </div>
-
-    <div class="chart-container-ios mt-3">
-      <canvas id="visitChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+    <div class="col-lg-6">
+      <div class="main-card">
+        <div class="chart-container-ios">
+          <canvas id="visitChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6">
+      <div class="main-card">
+        <div class="chart-container-ios">
+          <canvas id="countChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-12">
+      <div class="main-card">
+        <div class="chart-container-ios">
+          <canvas id="cumulativeChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -59,6 +79,8 @@ document.addEventListener("DOMContentLoaded", function () {
     const colors = ['#e74c3c','#3498db','#2ecc71','#9b59b6','#f1c40f','#e67e22','#1abc9c','#34495e'];
 
     const ctx = document.getElementById('visitChart');
+    const countCtx = document.getElementById('countChart');
+    const cumCtx = document.getElementById('cumulativeChart');
     const chart = new Chart(ctx, {
         type: 'scatter',
         data: { datasets: [] },
@@ -79,6 +101,16 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
             }
         }
+    });
+    const countChart = new Chart(countCtx, {
+        type: 'bar',
+        data: { labels: [], datasets: [{ label: 'Sessions', data: [], backgroundColor: '#3498db' }] },
+        options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } } }
+    });
+    const cumChart = new Chart(cumCtx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Total Sessions', data: [], borderColor: '#e67e22', fill: false }] },
+        options: { responsive: true, scales: { y: { beginAtZero: true } } }
     });
 
     function getRange(range) {
@@ -110,6 +142,8 @@ document.addEventListener("DOMContentLoaded", function () {
         const sessions = [];
         let earliest = null;
         let latest = null;
+        const trackTotals = {};
+        trackNames.forEach(n => trackTotals[n] = 0);
 
         trackNames.forEach(name => {
             trackData[name].forEach(d => {
@@ -128,6 +162,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     key = dtCopy.toISOString().slice(0, 10);
                 }
                 sessions.push({ track: name, key: key, date: dt });
+                trackTotals[name] += 1;
             });
         });
 
@@ -181,7 +216,17 @@ document.addEventListener("DOMContentLoaded", function () {
             showLine: false
         }));
 
-        return { labels, datasets, maxCount };
+        const counts = trackNames.map(n => trackTotals[n]);
+
+        let cumulative = [];
+        let total = 0;
+        sessions.forEach(s => {
+            total += 1;
+            const label = s.date.toISOString().slice(0,10);
+            cumulative.push({ x: label, y: total });
+        });
+
+        return { labels, datasets, maxCount, counts, cumulative };
     }
 
     function updateChart() {
@@ -192,6 +237,12 @@ document.addEventListener("DOMContentLoaded", function () {
         chart.data.datasets = result.datasets;
         chart.options.scales.y.max = result.maxCount + 1;
         chart.update();
+        countChart.data.labels = trackNames;
+        countChart.data.datasets[0].data = result.counts;
+        countChart.update();
+        cumChart.data.labels = result.cumulative.map(d => d.x);
+        cumChart.data.datasets[0].data = result.cumulative.map(d => d.y);
+        cumChart.update();
     }
 
     document.getElementById('rangeFilter').addEventListener('change', function () {


### PR DESCRIPTION
## Summary
- warn users that Circuit and international results may not import correctly
- allow manual time filter on race detail page
- show chart and table side-by-side on track page
- redesign Visit Data into multi-card dashboard with additional charts

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ac8277d9c8326a5b95de1e54f568d