### PR TITLE
Add manual date filter and new visit data charts

### DIFF
--- a/templates/profile_found.html
+++ b/templates/profile_found.html
@@ -23,6 +23,9 @@
                     <i class="bi bi-cloud-arrow-down"></i> Import New Races
                 </button>
             </form>
+            <div class="alert alert-warning p-1 mb-2" role="alert">
+                <small>Imported results from K1 Circuit and international locations may be incomplete.</small>
+            </div>
             
             <div class="d-grid gap-2">
                 <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">

--- a/templates/race.html
+++ b/templates/race.html
@@ -25,6 +25,10 @@
       <canvas id="lapChart" style="touch-action:none; width:100%; height:400px;"></canvas>
     </div>
     <button id="toggleOutliers" class="btn btn-warning btn-sm mb-1">Filter Outliers</button>
+    <div class="input-group input-group-sm mb-1 mt-1" style="max-width: 200px;">
+      <input type="number" step="0.001" id="manualMax" class="form-control" placeholder="Max lap (s)">
+      <button id="applyManualMax" class="btn btn-outline-secondary">Apply</button>
+    </div>
     <div id="outlierInfo" class="text-muted small mb-3"></div>
   </div>
 </div>
@@ -46,6 +50,7 @@
 
   const outlierFlags = calcOutliers(lapTimes);
   let hideOutliers = false;
+  let manualMax = null;
 
   const chart = new Chart(ctx, {
     type: 'line',
@@ -108,10 +113,12 @@
     const vals = [];
     const removed = [];
     for (let i = 0; i < lapTimes.length; i++) {
-      if (!hideOutliers || !outlierFlags[i]) {
+      const isOutlier = outlierFlags[i];
+      const withinMax = manualMax === null || lapTimes[i] <= manualMax;
+      if ((!hideOutliers || !isOutlier) && withinMax) {
         labels.push(`Lap ${i + 1}`);
         vals.push(lapTimes[i]);
-      } else {
+      } else if (hideOutliers && isOutlier) {
         removed.push(`Lap ${i + 1}: ${lapTimes[i].toFixed(3)}s`);
       }
     }
@@ -132,6 +139,15 @@
     btn.textContent = hideOutliers ? 'Show Outliers' : 'Filter Outliers';
     updateChart();
   });
+
+  const applyBtn = document.getElementById('applyManualMax');
+  if (applyBtn) {
+    applyBtn.addEventListener('click', () => {
+      const val = parseFloat(document.getElementById('manualMax').value);
+      if (!isNaN(val)) manualMax = val; else manualMax = null;
+      updateChart();
+    });
+  }
 
   updateChart();
   });

--- a/templates/results.html
+++ b/templates/results.html
@@ -22,6 +22,9 @@
            class="btn btn-sm btn-primary">
           Import New Races
         </a>
+        <div class="alert alert-warning p-1 mt-2 mb-0" role="alert">
+          <small>Imported results from K1 Circuit and international locations may be incomplete.</small>
+        </div>
       </div>
     </div>
   </div>

--- a/templates/track.html
+++ b/templates/track.html
@@ -10,8 +10,10 @@
             </a>
         </div>
 
-        <!-- Chart Section -->
-        <div class="mt-3">
+        <!-- Chart & Table Row -->
+        <div class="row mt-3 g-3">
+          <div class="col-lg-6">
+            <!-- Chart Section -->
             <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
                 <div>
                     <label for="timeFilter" class="form-label me-2">Lap View:</label>
@@ -61,12 +63,13 @@
                 <input type="number" id="driftDays" value="1" min="0" class="form-control form-control-sm d-inline w-auto ms-1 me-1">days
                 <button id="applyDriftFilter" class="btn btn-outline-secondary btn-sm chart-btn">Apply</button>
             </div>
-        </div>
+          </div>
 
-        <!-- Session Table Section -->
-        <div class="table-container-ios mt-4">
-            <div class="small text-muted mb-1">Click any column header to sort the table. Click any session date to view session details.</div>
-            <table id="lapsTable" class="table table-striped">
+          <!-- Session Table Section -->
+          <div class="col-lg-6">
+            <div class="table-container-ios mt-4 mt-lg-0">
+                <div class="small text-muted mb-1">Click any column header to sort the table. Click any session date to view session details.</div>
+                <table id="lapsTable" class="table table-striped">
                 <thead>
                     <tr>
                         <th class="sortable-header"><button type="button" class="btn btn-light btn-sm sort-button w-100" onclick="sortTable(0)">Date <span class="sort-icons">⇅</span></button></th>
@@ -97,10 +100,12 @@
                     {% endfor %}
                 </tbody>
             </table>
-</div>
-<div class="text-start mb-2">
-  <button id="toggleRows" class="btn btn-outline-secondary btn-sm chart-btn">Show All</button>
-</div>
+            </div>
+            <div class="text-start mb-2">
+              <button id="toggleRows" class="btn btn-outline-secondary btn-sm chart-btn">Show All</button>
+            </div>
+          </div>
+        </div>
     </div>
 </div>
 

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -2,22 +2,23 @@
 
 {% block content %}
 <div class="container mt-4">
-  <div class="main-card">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h2>Visit Data</h2>
-      <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">Back to Results</a>
-    </div>
-    <p><strong>Favourite Track:</strong> {{ favourite_track }}</p>
-    <p class="text-dark mb-2"><em>⚠️ This page is a work in progress ⚠️</em></p>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Visit Data</h2>
+    <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">Back to Results</a>
+  </div>
+  <p><strong>Favourite Track:</strong> {{ favourite_track }}</p>
+  <p class="text-dark mb-2"><em>⚠️ This page is a work in progress ⚠️</em></p>
 
-    <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-      <label for="rangeFilter" class="form-label me-2">Time Range:</label>
-      <select id="rangeFilter" class="form-select form-select-sm d-inline w-auto">
-        <option value="all" selected>All Time</option>
+  <div class="row g-3">
+    <div class="col-12">
+      <div class="main-card">
+        <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+          <label for="rangeFilter" class="form-label me-2">Time Range:</label>
+          <select id="rangeFilter" class="form-select form-select-sm d-inline w-auto">
+            <option value="all" selected>All Time</option>
         <option value="this_week">This Week</option>
         <option value="this_month">This Month</option>
         <option value="this_year">This Year</option>
-        <option value="custom">Custom Range</option>
       </select>
       <label for="sortBy" class="form-label ms-2 me-2">Sort By:</label>
       <select id="sortBy" class="form-select form-select-sm d-inline w-auto">
@@ -26,16 +27,45 @@
         <option value="month" selected>Month</option>
         <option value="year">Year</option>
       </select>
-      <div id="customRangeInputs" style="display:none;">
-        <label for="fromDate" class="form-label me-1">From:</label>
-        <input type="date" id="fromDate" class="form-control form-control-sm d-inline w-auto me-2">
-        <label for="toDate" class="form-label me-1">To:</label>
-        <input type="date" id="toDate" class="form-control form-control-sm d-inline w-auto">
+        </div>
+        <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+          <label for="fromDate" class="form-label me-1">From:</label>
+          <input type="date" id="fromDate" class="form-control form-control-sm d-inline w-auto me-2">
+          <label for="toDate" class="form-label me-1">To:</label>
+          <input type="date" id="toDate" class="form-control form-control-sm d-inline w-auto me-2">
+          <button id="applyManualDate" class="btn btn-outline-secondary btn-sm">Apply</button>
+          <button id="clearManualDate" class="btn btn-outline-secondary btn-sm">Clear</button>
+        </div>
+        </div>
       </div>
     </div>
-
-    <div class="chart-container-ios mt-3">
-      <canvas id="visitChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+    <div class="col-lg-6">
+      <div class="main-card">
+        <div class="chart-container-ios">
+          <canvas id="visitChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6">
+      <div class="main-card">
+        <div class="chart-container-ios">
+          <canvas id="pieChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6">
+      <div class="main-card">
+        <div class="chart-container-ios">
+          <canvas id="cumulativeChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6">
+      <div class="main-card">
+        <div class="chart-container-ios">
+          <canvas id="dowChart" style="touch-action:none; width:100%; height:400px;"></canvas>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -58,27 +88,64 @@ document.addEventListener("DOMContentLoaded", function () {
     const trackNames = Object.keys(trackData);
     const colors = ['#e74c3c','#3498db','#2ecc71','#9b59b6','#f1c40f','#e67e22','#1abc9c','#34495e'];
 
+    let manualFrom = null;
+    let manualTo = null;
+
     const ctx = document.getElementById('visitChart');
+    const pieCtx = document.getElementById('pieChart');
+    const cumCtx = document.getElementById('cumulativeChart');
+    const dowCtx = document.getElementById('dowChart');
     const chart = new Chart(ctx, {
-        type: 'scatter',
-        data: { datasets: [] },
+        type: 'bar',
+        data: { labels: [], datasets: [] },
+        options: {
+            responsive: true,
+            plugins: { legend: { display: true } },
+            scales: {
+                x: { stacked: true, title: { display: true, text: 'Date' } },
+                y: { beginAtZero: true, stacked: true, ticks: { stepSize: 1 }, title: { display: true, text: 'Sessions' } }
+            }
+        }
+    });
+    const pieChart = new Chart(pieCtx, {
+        type: 'pie',
+        data: { labels: [], datasets: [{ data: [], backgroundColor: colors, borderColor: '#000', borderWidth: 1 }] },
         options: {
             responsive: true,
             plugins: {
-                legend: { display: true },
-                tooltip: { enabled: false }
-            },
-            hover: { mode: null },
-            interaction: { mode: null },
-            scales: {
-                x: { type: 'category', title: { display: true, text: 'Date' } },
-                y: {
-                    beginAtZero: true,
-                    ticks: { stepSize: 1 },
-                    title: { display: true, text: 'Sessions' }
+                legend: {
+                    position: 'bottom',
+                    labels: {
+                        generateLabels(chart) {
+                            const counts = chart.data.datasets[0].data;
+                            const total = counts.reduce((a,b) => a+b, 0) || 1;
+                            return chart.data.labels.map((label,i) => {
+                                const value = counts[i] || 0;
+                                const pct = ((value/total)*100).toFixed(1);
+                                return {
+                                    text: `${label}: ${pct}% (${value})`,
+                                    fillStyle: colors[i % colors.length],
+                                    strokeStyle: '#000',
+                                    lineWidth: 1,
+                                    hidden: false,
+                                    index: i
+                                };
+                            });
+                        }
+                    }
                 }
             }
         }
+    });
+    const cumChart = new Chart(cumCtx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Total Sessions', data: [], borderColor: '#e67e22', fill: false }] },
+        options: { responsive: true, scales: { y: { beginAtZero: true } } }
+    });
+    const dowChart = new Chart(dowCtx, {
+        type: 'bar',
+        data: { labels: ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'], datasets: [{ label: 'Visits', data: [], backgroundColor: '#3498db' }] },
+        options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } } }
     });
 
     function getRange(range) {
@@ -94,94 +161,85 @@ document.addEventListener("DOMContentLoaded", function () {
             fromDate.setDate(now.getDate() - day + 1);
         } else if (range === 'this_year') {
             fromDate = new Date(now.getFullYear(), 0, 1);
-        } else if (range === 'custom') {
-            const f = document.getElementById('fromDate').value;
-            const t = document.getElementById('toDate').value;
-            if (f && t) {
-                fromDate = new Date(f);
-                toDate = new Date(t);
-            }
         }
+
+        if (manualFrom) fromDate = manualFrom;
+        if (manualTo) toDate = manualTo;
         return { fromDate, toDate };
     }
 
     function buildDatasets(sortBy, range) {
         const { fromDate, toDate } = getRange(range);
+        const trackTotals = {};
+        const countsPerKeyPerTrack = {};
+        trackNames.forEach(n => { trackTotals[n] = 0; countsPerKeyPerTrack[n] = {}; });
         const sessions = [];
-        let earliest = null;
-        let latest = null;
 
         trackNames.forEach(name => {
             trackData[name].forEach(d => {
                 const dt = new Date(d);
                 if (fromDate && dt < fromDate) return;
                 if (toDate && dt > toDate) return;
-                if (!earliest || dt < earliest) earliest = dt;
-                if (!latest || dt > latest) latest = dt;
                 let key = d;
-                if (sortBy === 'month') key = d.slice(0, 7);
-                else if (sortBy === 'year') key = d.slice(0, 4);
+                if (sortBy === 'month') key = d.slice(0,7);
+                else if (sortBy === 'year') key = d.slice(0,4);
                 else if (sortBy === 'week') {
                     const dtCopy = new Date(dt);
                     const day = dtCopy.getDay() || 7;
-                    dtCopy.setDate(dtCopy.getDate() - day + 1); // Monday start
-                    key = dtCopy.toISOString().slice(0, 10);
+                    dtCopy.setDate(dtCopy.getDate() - day + 1);
+                    key = dtCopy.toISOString().slice(0,10);
                 }
-                sessions.push({ track: name, key: key, date: dt });
+                countsPerKeyPerTrack[name][key] = (countsPerKeyPerTrack[name][key] || 0) + 1;
+                trackTotals[name] += 1;
+                sessions.push(dt);
             });
         });
 
-        if (!sessions.length) {
-            return { labels: [], datasets: [], maxCount: 0 };
-        }
-
-        sessions.sort((a, b) => a.date - b.date);
-
-        const countsPerKey = {};
-        const dataPerTrack = {};
-        trackNames.forEach(name => { dataPerTrack[name] = []; });
-        let maxCount = 0;
-
-        sessions.forEach(s => {
-            countsPerKey[s.key] = (countsPerKey[s.key] || 0) + 1;
-            const y = countsPerKey[s.key];
-            dataPerTrack[s.track].push({ x: s.key, y: y });
-            if (y > maxCount) maxCount = y;
-        });
-
-        const start = fromDate || earliest;
-        const end = toDate || latest;
-        const labels = [];
-        const current = new Date(start);
-        while (current <= end) {
-            if (sortBy === 'month') {
-                labels.push(current.toISOString().slice(0, 7));
-                current.setMonth(current.getMonth() + 1);
-            } else if (sortBy === 'year') {
-                labels.push(String(current.getFullYear()));
-                current.setFullYear(current.getFullYear() + 1);
-            } else if (sortBy === 'week') {
-                const weekStart = new Date(current);
-                const day = weekStart.getDay() || 7;
-                weekStart.setDate(weekStart.getDate() - day + 1);
-                labels.push(weekStart.toISOString().slice(0, 10));
-                current.setDate(current.getDate() + 7);
-            } else {
-                labels.push(current.toISOString().slice(0, 10));
-                current.setDate(current.getDate() + 1);
-            }
-        }
+        const keysSet = new Set();
+        trackNames.forEach(n => Object.keys(countsPerKeyPerTrack[n]).forEach(k => keysSet.add(k)));
+        const labels = Array.from(keysSet).sort();
 
         const datasets = trackNames.map((name, idx) => ({
             label: name,
-            data: dataPerTrack[name],
-            borderColor: colors[idx % colors.length],
+            data: labels.map(k => countsPerKeyPerTrack[name][k] || 0),
             backgroundColor: colors[idx % colors.length],
-            pointRadius: 5,
-            showLine: false
+            borderColor: '#000',
+            borderWidth: 1,
+            stack: 'sessions'
         }));
 
-        return { labels, datasets, maxCount };
+        const counts = trackNames.map(n => trackTotals[n]);
+
+        // cumulative totals
+        const totalsByLabel = {};
+        sessions.forEach(dt => {
+            let label = dt.toISOString().slice(0,10);
+            if (sortBy === 'month') label = label.slice(0,7);
+            else if (sortBy === 'year') label = label.slice(0,4);
+            else if (sortBy === 'week') {
+                const copy = new Date(dt);
+                const day = copy.getDay() || 7;
+                copy.setDate(copy.getDate() - day + 1);
+                label = copy.toISOString().slice(0,10);
+            }
+            totalsByLabel[label] = (totalsByLabel[label] || 0) + 1;
+        });
+        const cumulative = [];
+        let running = 0;
+        labels.forEach(label => {
+            running += totalsByLabel[label] || 0;
+            cumulative.push(running);
+        });
+
+        // visits by day of week
+        const dow = [0,0,0,0,0,0,0];
+        sessions.forEach(dt => {
+            let idx = dt.getDay();
+            idx = (idx + 6) % 7; // Monday=0
+            dow[idx] += 1;
+        });
+
+        return { labels, datasets, counts, cumulative, dow };
     }
 
     function updateChart() {
@@ -190,17 +248,32 @@ document.addEventListener("DOMContentLoaded", function () {
         const result = buildDatasets(sortBy, range);
         chart.data.labels = result.labels;
         chart.data.datasets = result.datasets;
-        chart.options.scales.y.max = result.maxCount + 1;
         chart.update();
+        pieChart.data.labels = trackNames;
+        pieChart.data.datasets[0].data = result.counts;
+        pieChart.update();
+        cumChart.data.labels = result.labels;
+        cumChart.data.datasets[0].data = result.cumulative;
+        cumChart.update();
+        dowChart.data.datasets[0].data = result.dow;
+        dowChart.update();
     }
 
-    document.getElementById('rangeFilter').addEventListener('change', function () {
-        document.getElementById('customRangeInputs').style.display = this.value === 'custom' ? 'block' : 'none';
+    document.getElementById('rangeFilter').addEventListener('change', updateChart);
+    document.getElementById('sortBy').addEventListener('change', updateChart);
+    document.getElementById('applyManualDate').addEventListener('click', () => {
+        const f = document.getElementById('fromDate').value;
+        const t = document.getElementById('toDate').value;
+        manualFrom = f ? new Date(f) : null;
+        manualTo = t ? new Date(t) : null;
         updateChart();
     });
-    document.getElementById('sortBy').addEventListener('change', updateChart);
-    document.getElementById('fromDate').addEventListener('change', updateChart);
-    document.getElementById('toDate').addEventListener('change', updateChart);
+    document.getElementById('clearManualDate').addEventListener('click', () => {
+        manualFrom = manualTo = null;
+        document.getElementById('fromDate').value = '';
+        document.getElementById('toDate').value = '';
+        updateChart();
+    });
 
     updateChart();
 });


### PR DESCRIPTION
## Summary
- restyle import warnings as alerts
- restore WIP notice on the visit data page
- include manual date range filter
- replace dot chart with stacked bar and add pie/cumulative/day-of-week charts

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ac8277d9c8326a5b95de1e54f568d