### PR TITLE
UI tweaks and chart fixes

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -20,6 +20,10 @@ body {
     overflow: hidden; /* clip background inside rounded corners */
 }
 
+.wide-card {
+    max-width: 1200px;
+}
+
 /* This creates the blended background */
 .auth-card::before,
 .main-card::before {

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,6 +28,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-piechart-outlabels"></script>
     <footer class="text-center mt-4 mb-2 text-muted small">
         This is an unofficial app. Not affiliated with or endorsed by K1 Speed.
     </footer>

--- a/templates/race.html
+++ b/templates/race.html
@@ -26,7 +26,7 @@
     </div>
     <button id="toggleOutliers" class="btn btn-warning btn-sm mb-1">Filter Outliers</button>
     <div class="input-group input-group-sm mb-1 mt-1" style="max-width: 200px;">
-      <input type="number" step="0.001" id="manualMax" class="form-control" placeholder="Max lap (s)">
+      <input type="number" step="0.001" id="manualMax" class="form-control" placeholder="Max lap time (s)">
       <button id="applyManualMax" class="btn btn-outline-secondary">Apply</button>
     </div>
     <div id="outlierInfo" class="text-muted small mb-3"></div>
@@ -82,14 +82,7 @@
             label: ctx => `Lap ${ctx.dataIndex + 1}: ${lapTimes[ctx.dataIndex].toFixed(3)}s`
           }
         },
-        zoom: {
-          pan: { enabled: true, mode: 'x' },
-          zoom: {
-            wheel: { enabled: true },
-            pinch: { enabled: true },
-            mode: 'x'
-          }
-        }
+        zoom: false
       },
       scales: {
         x: {

--- a/templates/results.html
+++ b/templates/results.html
@@ -6,20 +6,19 @@
   <!-- Profile header + action buttons (without picture) -->
   <div class="main-card mb-4 p-4">
     <div>
-      <h3 class="mb-1">{{ username }}</h3>
-      <p class="mb-1"><strong>Total Races:</strong>
-        {{ total_races }}</p>
+      <h3 class="mb-2">{{ username }}</h3>
+      <p class="mb-1">Total Races: <strong>{{ total_races }}</strong></p>
+      {% if racer_since %}<p class="mb-1">Racer Since: {{ racer_since }}</p>{% endif %}
+      {% if favourite_track %}<p class="mb-1">Favourite Location: {{ favourite_track }}</p>{% endif %}
+      {% if favourite_day %}<p class="mb-3">Favourite Day: {{ favourite_day }}</p>{% endif %}
       <div class="mt-2">
-        <a href="{{ url_for('profile_setup') }}"
-           class="btn btn-sm btn-outline-secondary me-2">
+        <a href="{{ url_for('profile_setup') }}" class="btn btn-sm btn-outline-secondary me-2">
           Edit Profile
         </a>
-        <a href="{{ url_for('visit_data') }}"
-           class="btn btn-sm btn-outline-secondary me-2">
+        <a href="{{ url_for('visit_data') }}" class="btn btn-sm btn-primary me-2">
           Visit Data
         </a>
-        <a href="{{ url_for('import_loading') }}"
-           class="btn btn-sm btn-primary">
+        <a href="{{ url_for('import_loading') }}" class="btn btn-sm btn-success">
           Import New Races
         </a>
         <div class="alert alert-warning p-1 mt-2 mb-0" role="alert">

--- a/templates/track.html
+++ b/templates/track.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="container mt-4">
-    <div class="main-card">
+    <div class="main-card wide-card">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h2>{{ track_name }} Sessions</h2>
             <a href="{{ url_for('download', track_name=track_name) }}" class="btn btn-primary">
@@ -12,7 +12,7 @@
 
         <!-- Chart & Table Row -->
         <div class="row mt-3 g-3">
-          <div class="col-lg-6">
+          <div class="col-lg-6 col-xl-5">
             <!-- Chart Section -->
             <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
                 <div>
@@ -66,7 +66,7 @@
           </div>
 
           <!-- Session Table Section -->
-          <div class="col-lg-6">
+          <div class="col-lg-6 col-xl-7">
             <div class="table-container-ios mt-4 mt-lg-0">
                 <div class="small text-muted mb-1">Click any column header to sort the table. Click any session date to view session details.</div>
                 <table id="lapsTable" class="table table-striped">

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -4,9 +4,15 @@
 <div class="container mt-4">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h2>Visit Data</h2>
-    <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">Back to Results</a>
+    <a href="{{ url_for('results') }}" class="btn btn-primary">Back to Results</a>
   </div>
-  <p><strong>Favourite Track:</strong> {{ favourite_track }}</p>
+  <div class="mb-3">
+    <h5 class="mb-1">{{ username }}</h5>
+    <p class="mb-1">Total Races: <strong>{{ total_races }}</strong></p>
+    {% if racer_since %}<p class="mb-1">Racer Since: {{ racer_since }}</p>{% endif %}
+    {% if favourite_track %}<p class="mb-1">Favourite Location: {{ favourite_track }}</p>{% endif %}
+    {% if favourite_day %}<p class="mb-0">Favourite Day: {{ favourite_day }}</p>{% endif %}
+  </div>
   <p class="text-dark mb-2"><em>⚠️ This page is a work in progress ⚠️</em></p>
 
   <div class="row g-3">
@@ -143,28 +149,12 @@ document.addEventListener("DOMContentLoaded", function () {
         options: {
             responsive: true,
             plugins: {
-                legend: {
-                    position: 'right',
-                    labels: {
-                        generateLabels(chart) {
-                            const counts = chart.data.datasets[0].data;
-                            const total = counts.reduce((a,b) => a+b, 0) || 1;
-                            return chart.data.labels.map((label,i) => {
-                                const value = counts[i] || 0;
-                                const pct = ((value/total)*100).toFixed(1);
-                                return {
-                                    text: `${label}: ${pct}% (${value})`,
-                                    fillStyle: colors[i % colors.length],
-                                    strokeStyle: '#000',
-                                    lineWidth: 1,
-                                    hidden: false,
-                                    index: i
-                                };
-                            });
-                        },
-                        boxWidth: 20,
-                        padding: 15
-                    }
+                legend: { display: false },
+                outlabels: {
+                    text: '%l %p',
+                    color: '#000',
+                    stretch: 15,
+                    font: { resizable: true, minSize: 12, maxSize: 18 }
                 },
                 tooltip: {
                     callbacks: {
@@ -199,9 +189,9 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
             ] 
         },
-        options: { 
-            responsive: true, 
-            scales: { 
+        options: {
+            responsive: true,
+            scales: {
                 y: { beginAtZero: true },
                 x: {
                     title: {
@@ -214,6 +204,14 @@ document.addEventListener("DOMContentLoaded", function () {
                 tooltip: {
                     mode: 'index',
                     intersect: false
+                },
+                zoom: {
+                    pan: { enabled: true, mode: 'x' },
+                    zoom: {
+                        wheel: { enabled: true },
+                        pinch: { enabled: true },
+                        mode: 'x'
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- beautify summary cards in results and visit data pages
- add racer stats in backend
- make visit data pie chart use outside labels
- add zooming to cumulative chart and disable zoom on race chart
- widen track details card and layout
- show back/visit data buttons more prominently

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686c9f3043188326843f973340499fd2