### PR TITLE
Fix pie label plugin guard

### DIFF
--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -114,6 +114,9 @@ document.addEventListener("DOMContentLoaded", function () {
     const pieLabelPlugin = {
         id: 'pieLabelPlugin',
         afterDraw(chart, args, opts) {
+            if (chart.config.type !== 'pie' || !chart.data.datasets.length) {
+                return;
+            }
             const { ctx } = chart;
             const total = chart.data.datasets[0].data.reduce((a, b) => a + b, 0);
             chart.getDatasetMeta(0).data.forEach((arc, i) => {


### PR DESCRIPTION
## Summary
- safeguard `pieLabelPlugin` from running on non-pie charts or empty datasets

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ca82260088326b7fd56f9727d011d