### PR TITLE
Fix charts layout and add track filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -500,10 +500,12 @@ def visit_data():
             all_sessions.extend(t.sessions)
 
     visit_data = {}
+    track_counts = {}
     for t in user.tracks:
         dates = [s.date.strftime('%Y-%m-%dT%H:%M:%S') for s in sorted(t.sessions, key=lambda s: s.date)]
         if dates:
             visit_data[t.display_name] = dates
+            track_counts[t.display_name] = len(dates)
 
     racer_since = None
     fav_day = None
@@ -517,9 +519,12 @@ def visit_data():
 
     total_races = len(all_sessions)
 
+    track_options = sorted(track_counts.items(), key=lambda x: x[1], reverse=True)
+
     return render_template('visit_data.html',
                            favourite_track=favourite_track,
                            visit_data=visit_data,
+                           track_options=track_options,
                            username=user.username,
                            total_races=total_races,
                            racer_since=racer_since,

--- a/templates/profile_found.html
+++ b/templates/profile_found.html
@@ -24,9 +24,6 @@
                 </button>
             </form>
 
-            <div class="alert alert-warning p-1 mb-2" role="alert">
-                <small>Results from K1 Circuit or international tracks might not be detected correctly.</small>
-            </div>
             
             <div class="d-grid gap-2">
                 <a href="{{ url_for('results') }}" class="btn btn-outline-secondary">

--- a/templates/results.html
+++ b/templates/results.html
@@ -22,7 +22,7 @@
           Import New Races
         </a>
         <div class="alert alert-warning p-1 mt-2 mb-0" role="alert">
-          <small>Results from K1 Circuit or international tracks might not be detected correctly.</small>
+          <small>Results from K1 Circuit or International tracks might not be detected correctly.</small>
         </div>
       </div>
     </div>

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -34,6 +34,13 @@
             <option value="month" selected>Month</option>
             <option value="year">Year</option>
           </select>
+          <label for="trackSelect" class="form-label ms-2 me-2">Track:</label>
+          <select id="trackSelect" class="form-select form-select-sm d-inline w-auto">
+            <option value="all" selected>All Tracks</option>
+            {% for name, count in track_options %}
+            <option value="{{ name }}">{{ name }} ({{ count }})</option>
+            {% endfor %}
+          </select>
         </div>
         <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
           <label for="fromDate" class="form-label me-1">From:</label>
@@ -129,7 +136,8 @@
 <script>
 document.addEventListener("DOMContentLoaded", function () {
     const trackData = {{ visit_data | tojson }};
-    const trackNames = Object.keys(trackData);
+    const allTrackNames = Object.keys(trackData);
+    let trackNames = allTrackNames.slice();
     const colors = ['#ff7665','#3498db','#2ecc71','#9b59b6','#f1c40f','#e67e22','#1abc9c','#34495e'];
 
     let manualFrom = null;
@@ -140,6 +148,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const cumCtx = document.getElementById('cumulativeChart');
     const dowCtx = document.getElementById('dowChart');
     const hourlyCtx = document.getElementById('hourlyChart');
+    const trackSelect = document.getElementById('trackSelect');
 
     
     const chart = new Chart(ctx, {
@@ -147,7 +156,8 @@ document.addEventListener("DOMContentLoaded", function () {
         data: { labels: [], datasets: [] },
         options: {
             responsive: true,
-            plugins: { 
+            maintainAspectRatio: false,
+            plugins: {
                 legend: { 
                     display: true,
                     position: 'bottom',
@@ -181,6 +191,7 @@ document.addEventListener("DOMContentLoaded", function () {
         data: { labels: [], datasets: [{ data: [], backgroundColor: colors, borderColor: '#000', borderWidth: 1 }] },
         options: {
             responsive: true,
+            maintainAspectRatio: false,
             plugins: {
                 legend: { display: true, position: 'bottom' },
                 tooltip: {
@@ -218,6 +229,7 @@ document.addEventListener("DOMContentLoaded", function () {
         },
         options: {
             responsive: true,
+            maintainAspectRatio: false,
             scales: {
                 y: { beginAtZero: true },
                 x: {
@@ -250,9 +262,10 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
             ] 
         },
-        options: { 
-            responsive: true, 
-            plugins: { 
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
                 legend: { display: false } 
             }, 
             scales: { 
@@ -286,6 +299,7 @@ document.addEventListener("DOMContentLoaded", function () {
         },
         options: {
             responsive: true,
+            maintainAspectRatio: false,
             plugins: {
                 legend: {
                     display: false
@@ -414,9 +428,15 @@ document.addEventListener("DOMContentLoaded", function () {
         return { labels, datasets, counts, cumulative, dow, hourlyCounts };
     }
 
+    function updateTrackSelection() {
+        const selected = trackSelect.value;
+        trackNames = selected === 'all' ? allTrackNames.slice() : [selected];
+    }
+
     function updateChart() {
         const range = document.getElementById('rangeFilter').value;
         const sortBy = document.getElementById('sortBy').value;
+        updateTrackSelection();
         const result = buildDatasets(sortBy, range);
         
         chart.data.labels = result.labels;
@@ -440,6 +460,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     document.getElementById('rangeFilter').addEventListener('change', updateChart);
     document.getElementById('sortBy').addEventListener('change', updateChart);
+    trackSelect.addEventListener('change', updateChart);
     document.getElementById('applyManualDate').addEventListener('click', () => {
         const f = document.getElementById('fromDate').value;
         const t = document.getElementById('toDate').value;
@@ -454,6 +475,7 @@ document.addEventListener("DOMContentLoaded", function () {
         updateChart();
     });
 
+    updateTrackSelection();
     updateChart();
 });
 </script>


### PR DESCRIPTION
## Summary
- fix results page capitalization and remove warning from profile
- keep visit-data charts full size
- filter visit data by track

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cbf5da8f88326aa11eeecce6035dd