### PR TITLE
fix: expand visit charts to fill card height

### DIFF
--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -123,6 +123,10 @@
     min-height: 450px;
 }
 
+.chart-grid .chart-card .chart-container-ios {
+    flex: 1;
+}
+
 .chart-title {
     margin-bottom: 0.5rem;
     font-weight: 500;


### PR DESCRIPTION
## Summary
- adjust visit page styles so chart containers expand vertically

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ccd7d46248326afefd84ffaf159b2