### PR TITLE
Enhance mobile view and chart labels

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
     <title>K1 Speed Tracker</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
@@ -27,6 +27,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1"></script>
     <footer class="text-center mt-4 mb-2 text-muted small">
         This is an unofficial app. Not affiliated with or endorsed by K1 Speed.

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -112,7 +112,7 @@
 
 .chart-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 0.5rem;
     align-items: stretch;
 }
@@ -160,14 +160,22 @@ document.addEventListener("DOMContentLoaded", function () {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { 
+                legend: {
                     display: true,
                     position: 'bottom',
                     labels: {
                         boxWidth: 20,
                         padding: 20
                     }
-                } 
+                },
+                datalabels: {
+                    color: '#000',
+                    anchor: 'end',
+                    align: 'start',
+                    formatter: function(value) {
+                        return value > 0 ? value : '';
+                    }
+                }
             },
             scales: {
                 x: { 
@@ -205,6 +213,14 @@ document.addEventListener("DOMContentLoaded", function () {
                             const percentage = Math.round((value / total) * 100);
                             return `${label}: ${value} (${percentage}%)`;
                         }
+                    }
+                },
+                datalabels: {
+                    color: '#000',
+                    formatter: function(value, context) {
+                        const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                        const percentage = Math.round((value / total) * 100);
+                        return `${percentage}% (${value})`;
                     }
                 }
             }
@@ -268,8 +284,16 @@ document.addEventListener("DOMContentLoaded", function () {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: false } 
-            }, 
+                legend: { display: false },
+                datalabels: {
+                    color: '#000',
+                    anchor: 'end',
+                    align: 'start',
+                    formatter: function(value) {
+                        return value > 0 ? value : '';
+                    }
+                }
+            },
             scales: { 
                 y: { 
                     beginAtZero: true, 
@@ -305,6 +329,14 @@ document.addEventListener("DOMContentLoaded", function () {
             plugins: {
                 legend: {
                     display: false
+                },
+                datalabels: {
+                    color: '#000',
+                    anchor: 'end',
+                    align: 'start',
+                    formatter: function(value) {
+                        return value > 0 ? value : '';
+                    }
                 }
             },
             scales: {


### PR DESCRIPTION
## Summary
- prevent Safari auto zoom with `maximum-scale=1` viewport
- include `chartjs-plugin-datalabels` globally
- tweak grid layout for smaller screens
- display data labels on pie and bar charts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ebcd0b56083269b8c1481b3fa1fa7