### PR TITLE
Fix chart layout and enable datalabel plugin

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -29,6 +29,12 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1"></script>
+    <script>
+        // Register Chart.js plugins
+        if (window.Chart && window.ChartDataLabels) {
+            Chart.register(ChartDataLabels);
+        }
+    </script>
     <footer class="text-center mt-4 mb-2 text-muted small">
         This is an unofficial app. Not affiliated with or endorsed by K1 Speed.
     </footer>

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -117,6 +117,12 @@
     align-items: stretch;
 }
 
+@media (min-width: 992px) {
+    .chart-grid {
+        grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
+    }
+}
+
 .chart-grid .chart-card {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- improve chart grid layout for desktop
- register Chart.js datalabels plugin so labels show up on charts

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ec20067ac832685ae7eb2262f6188