### PR TITLE
Fix track image border and hide chart labels

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -110,11 +110,13 @@ body {
 }
 
 .track-card-img {
-    width: 100%;
+    display: block;
+    margin: 20px auto 0;
     max-height: 180px;
+    max-width: 100%;
+    width: auto;
     object-fit: contain;
     border-radius: 8px 8px 0 0;
-    margin-top: 20px; /* provide visual spacing so image is centered */
     outline: 2px solid #333;
 }
 

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -144,6 +144,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const calloutLabels = {
         id: 'calloutLabels',
         afterDatasetsDraw(chart, args, options) {
+            if (!options) return;
             const ctx = chart.ctx;
             const cfg = Object.assign({barThreshold: 20, pieAngle: 0.5, offset: 10}, options);
             ctx.save();
@@ -242,7 +243,6 @@ document.addEventListener("DOMContentLoaded", function () {
                         padding: 20
                     }
                 },
-                calloutLabels: {},
                 datalabels: { display: false }
             },
             scales: {
@@ -349,7 +349,6 @@ document.addEventListener("DOMContentLoaded", function () {
             maintainAspectRatio: false,
             plugins: {
                 legend: { display: false },
-                calloutLabels: {},
                 datalabels: { display: false }
             },
             scales: { 
@@ -388,7 +387,6 @@ document.addEventListener("DOMContentLoaded", function () {
                 legend: {
                     display: false
                 },
-                calloutLabels: {},
                 datalabels: { display: false }
             },
             scales: {


### PR DESCRIPTION
## Summary
- adjust track card image styling so the outline hugs the image
- change callout labels plugin to check for options
- enable custom labels only for the pie chart
- disable labels for other charts

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687026e2bbc88326ac493dcf6193d837