### PR TITLE
Fix chart labels and track card styling

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -102,6 +102,7 @@ body {
     padding: 0;
     text-align: left;
     transition: transform 0.2s;
+    border: 2px solid #333;
 }
 
 .track-card:hover {
@@ -116,15 +117,12 @@ body {
     max-width: 100%;
     width: auto;
     object-fit: contain;
-    border-radius: 8px 8px 0 0;
-    outline: 2px solid #333;
 }
 
 .track-card-placeholder {
     width: 100%;
     max-height: 180px;
     height: 180px;
-    border-radius: 8px 8px 0 0;
     margin-top: 20px;
     display: flex;
     align-items: center;

--- a/templates/race.html
+++ b/templates/race.html
@@ -82,7 +82,8 @@
             label: ctx => `Lap ${ctx.dataIndex + 1}: ${lapTimes[ctx.dataIndex].toFixed(3)}s`
           }
         },
-        zoom: false
+        zoom: false,
+        datalabels: { display: false }
       },
       scales: {
         x: {

--- a/templates/track.html
+++ b/templates/track.html
@@ -236,7 +236,8 @@ document.addEventListener("DOMContentLoaded", function () {
                         pinch: { enabled: true },
                         mode: 'x'
                     }
-                }
+                },
+                datalabels: { display: false }
             },
             scales: {
                 y: {

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -284,7 +284,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     }
                 },
                 calloutLabels: {},
-                datalabels: { display: false }
+                datalabels: { display: true }
             }
         }
     });


### PR DESCRIPTION
## Summary
- disable Chart.js datalabels for line charts
- enable datalabels on the pie chart
- give track cards a full border and rounded bottom edges

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68702925f1d08326b582b4cc7b8d25f9