### PR TITLE
Fix visit_data day sorting and add recent race info

### DIFF
--- a/app.py
+++ b/app.py
@@ -459,6 +459,10 @@ def results():
     if all_sessions:
         racer_since = min(all_sessions, key=lambda s: s.date).date.strftime('%Y-%m-%d')
 
+    most_recent = None
+    if all_sessions:
+        most_recent = max(all_sessions, key=lambda s: s.date).date.strftime('%Y-%m-%d')
+
     favourite_track = None
     if sorted_tracks:
         favourite_track = sorted_tracks[0][0]
@@ -479,7 +483,8 @@ def results():
         total_races=total_races,
         racer_since=racer_since,
         favourite_track=favourite_track,
-        favourite_day=fav_day
+        favourite_day=fav_day,
+        most_recent_race=most_recent
     )
 
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -9,6 +9,7 @@
       <h3 class="mb-2">{{ username }}</h3>
       <p class="mb-1">Total Races: <strong>{{ total_races }}</strong></p>
       {% if racer_since %}<p class="mb-1">Racer Since: {{ racer_since }}</p>{% endif %}
+      {% if most_recent_race %}<p class="mb-1">Most Recent Race: {{ most_recent_race }}</p>{% endif %}
       {% if favourite_track %}<p class="mb-1">Favourite Location: {{ favourite_track }}</p>{% endif %}
       {% if favourite_day %}<p class="mb-3">Favourite Day: {{ favourite_day }}</p>{% endif %}
       <div class="mt-2">

--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -450,7 +450,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     hourlyCounts[hour - 11]++;
                 }
                 
-                let key = d;
+                let key;
                 if (sortBy === 'month') key = d.slice(0,7);
                 else if (sortBy === 'year') key = d.slice(0,4);
                 else if (sortBy === 'week') {
@@ -458,6 +458,8 @@ document.addEventListener("DOMContentLoaded", function () {
                     const day = dtCopy.getDay() || 7;
                     dtCopy.setDate(dtCopy.getDate() - day + 1);
                     key = dtCopy.toISOString().slice(0,10);
+                } else {
+                    key = d.slice(0,10);
                 }
                 countsPerKeyPerTrack[name][key] = (countsPerKeyPerTrack[name][key] || 0) + 1;
                 trackTotals[name] += 1;


### PR DESCRIPTION
## Summary
- fix day sorting logic when building datasets for visit data charts
- show most recent race date on results page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687ed3dec6488326a9c5c76697bd5972