### PR TITLE
Fix Torrance track naming and restore visit data WIP notice

### DIFF
--- a/templates/visit_data.html
+++ b/templates/visit_data.html
@@ -2,6 +2,9 @@
 
 {% block content %}
 <div class="container mt-4">
+  <div class="alert alert-warning mb-3" role="alert">
+    🚧 Work in Progress – this page is under construction.
+  </div>
   <div class="row gx-1 gy-1">
     <div class="col-12">
       <div class="main-card chart-card h-100" style="min-height:auto;">


### PR DESCRIPTION
## Summary
- ensure single-track locations like Torrance drop the T1 suffix so images load
- fall back to non-T1 image files if a T1 image is missing
- add a work-in-progress warning banner to the Visit Data page

## Testing
- `python -m py_compile app.py`
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a056c0aad483268f4da161e1fbdaf6