### PR TITLE
Allow overriding import start date

### DIFF
--- a/templates/import_loading.html
+++ b/templates/import_loading.html
@@ -13,7 +13,8 @@
 
 <script>
     // Start import process immediately
-    fetch("{{ url_for('import_results') }}")
+    // Temporarily force search to begin on 2025-08-14 to recover missing sessions
+    fetch("{{ url_for('import_results', start_date='2025-08-14') }}")
         .then(response => response.json())
         .then(data => {
             if (data.status === 'success') {


### PR DESCRIPTION
## Summary
- allow manual start date override for IMAP search to recover missed sessions
- default fetch now searches from 2025-08-14 to locate missing races
- leaderboard now omits tracks with only one recorded session

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bca0d8b9308326beaadc60b32b17b1