### PR TITLE
Restore import start date and make session table scrollable

### DIFF
--- a/app.py
+++ b/app.py
@@ -353,17 +353,7 @@ def import_results():
               .first()
         )
 
-        # Allow manually overriding the search start date via query string to
-        # help recover missed sessions (expected format YYYY-MM-DD)
-        override = request.args.get('start_date')
-        if override:
-            try:
-                override_dt = datetime.strptime(override, '%Y-%m-%d')
-                since_str = override_dt.strftime('%d-%b-%Y')
-            except ValueError:
-                return jsonify(status='error',
-                               message='Invalid start_date format; use YYYY-MM-DD')
-        elif latest_row:
+        if latest_row:
             last_dt = latest_row[0]
             since_str = last_dt.strftime('%d-%b-%Y')  # e.g. "25-May-2025"
         else:

--- a/templates/import_loading.html
+++ b/templates/import_loading.html
@@ -13,8 +13,7 @@
 
 <script>
     // Start import process immediately
-    // Temporarily force search to begin on 2025-08-14 to recover missing sessions
-    fetch("{{ url_for('import_results', start_date='2025-08-14') }}")
+    fetch("{{ url_for('import_results') }}")
         .then(response => response.json())
         .then(data => {
             if (data.status === 'success') {

--- a/templates/track.html
+++ b/templates/track.html
@@ -129,11 +129,12 @@
 
 /* Table styles (unchanged) */
 .table-container-ios {
-    overflow-x: auto;
+    overflow: auto;
     -webkit-overflow-scrolling: touch;
     width: 100%;
     border-radius: 8px;
     margin-bottom: 1rem;
+    max-height: 400px;
 }
 .table-container-ios table {
     min-width: 600px;
@@ -436,6 +437,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const MAX_ROWS = 10;
     const table = document.getElementById('lapsTable');
     const btnToggle = document.getElementById('toggleRows');
+    const tableContainer = document.querySelector('.table-container-ios');
     const rows = Array.from(table.tBodies[0].rows);
     if (rows.length > MAX_ROWS) {
         rows.slice(MAX_ROWS).forEach(r => r.classList.add('d-none'));
@@ -444,9 +446,11 @@ document.addEventListener("DOMContentLoaded", function () {
             if (hidden.length) {
                 hidden.forEach(r => r.classList.remove('d-none'));
                 btnToggle.textContent = 'Show Less';
+                tableContainer.style.maxHeight = '80vh';
             } else {
                 rows.slice(MAX_ROWS).forEach(r => r.classList.add('d-none'));
                 btnToggle.textContent = 'Show All';
+                tableContainer.style.maxHeight = '400px';
             }
         });
     } else {
@@ -482,6 +486,7 @@ document.addEventListener("DOMContentLoaded", function () {
             if (!expanded && i >= MAX_ROWS) r.classList.add('d-none');
             else r.classList.remove('d-none');
         });
+        tableContainer.style.maxHeight = expanded ? '80vh' : '400px';
     };
 });
 </script>


### PR DESCRIPTION
## Summary
- Remove temporary `start_date` override so imports resume from the last saved session.
- Add vertical scrolling to the session table and expand card height when showing all rows.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bca438cf948326ac2ec71ab88bd385