### PR TITLE
Fix about page photo aspect ratios

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -260,11 +260,19 @@ table th {
     box-shadow: 0 8px 20px rgba(0,0,0,0.08);
 }
 
+.about-photo-slot--landscape {
+    aspect-ratio: 4 / 3;
+}
+
+.about-photo-slot--portrait {
+    aspect-ratio: 3 / 4;
+}
+
 .about-photo-img {
     display: block;
     width: 100%;
-    height: auto;
-    object-fit: contain;
+    height: 100%;
+    object-fit: cover;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- enforce landscape and portrait aspect ratios for about page photo slots
- ensure images fill their containers consistently with cover sizing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926c5c82c8c8326bbf56e1f8d061933)